### PR TITLE
Potential fix for code scanning alert no. 51: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,8 @@ name: Pylint
 
 on: [push]
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/QueryWeaver/security/code-scanning/51](https://github.com/FalkorDB/QueryWeaver/security/code-scanning/51)

To fix the problem, you should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. In this case, the workflow only needs to read the repository contents to check out code and run linting. The best way to fix this is to add the following block at the root level of the workflow file (above the `jobs:` key):

```yaml
permissions:
  contents: read
```

This change should be made in `.github/workflows/pylint.yml`, above the `jobs:` section. No additional methods, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
