### PR TITLE
Potential fix for code scanning alert no. 59: Incomplete string escaping or encoding

### DIFF
--- a/api/static/js/modules/chat.js
+++ b/api/static/js/modules/chat.js
@@ -210,6 +210,14 @@ export function pauseRequest() {
     }
 }
 
+/**
+ * Escapes a string for safe embedding in a single-quoted JavaScript string literal.
+ * Replaces backslashes and single quotes.
+ */
+function escapeForSingleQuotedJsString(str) {
+    return str.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
 export function addDestructiveConfirmationMessage(step) {
     const messageDiv = document.createElement('div');
     const messageDivContainer = document.createElement('div');
@@ -225,10 +233,10 @@ export function addDestructiveConfirmationMessage(step) {
         <div class="destructive-confirmation" data-confirmation-id="${confirmationId}">
             <div class="confirmation-text">${step.message.replace(/\n/g, '<br>')}</div>
             <div class="confirmation-buttons">
-                <button class="confirm-btn danger" onclick="handleDestructiveConfirmation('CONFIRM', '${step.sql_query.replace(/'/g, "\\'")}', '${confirmationId}')">
+                <button class="confirm-btn danger" onclick="handleDestructiveConfirmation('CONFIRM', '${escapeForSingleQuotedJsString(step.sql_query)}', '${confirmationId}')">
                     CONFIRM - Execute Query
                 </button>
-                <button class="cancel-btn" onclick="handleDestructiveConfirmation('CANCEL', '${step.sql_query.replace(/'/g, "\\'")}', '${confirmationId}')">
+                <button class="cancel-btn" onclick="handleDestructiveConfirmation('CANCEL', '${escapeForSingleQuotedJsString(step.sql_query)}', '${confirmationId}')">
                     CANCEL - Abort Operation
                 </button>
             </div>


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/QueryWeaver/security/code-scanning/59](https://github.com/FalkorDB/QueryWeaver/security/code-scanning/59)

To fix the problem, we need to ensure that both backslashes and single quotes are properly escaped in the string before embedding it in a JavaScript string literal. The best way is to first replace all backslashes (`\`) with double backslashes (`\\`), and then replace all single quotes (`'`) with escaped single quotes (`\'`). This should be done in that order to avoid double-escaping. Ideally, this escaping should be encapsulated in a helper function for clarity and reuse. The fix should be applied to both instances where `step.sql_query.replace(/'/g, "\\'")` is used (lines 228 and 231). The helper function can be defined within the same file, above its first use.

**Required changes:**
- Add a helper function (e.g., `escapeForSingleQuotedJsString`) that escapes backslashes and single quotes.
- Replace both instances of `step.sql_query.replace(/'/g, "\\'")` with a call to this helper function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
