### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,4 +1,6 @@
 name: Spellcheck
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/QueryWeaver/security/code-scanning/2](https://github.com/FalkorDB/QueryWeaver/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow to restrict the permissions of the GITHUB_TOKEN to the minimum required. In this case, the spellcheck job only needs to read the repository contents, so you should set `contents: read`. This can be done either at the root of the workflow (to apply to all jobs) or at the job level (to apply only to the `spellcheck` job). The simplest and most maintainable approach is to add the block at the root level, immediately after the workflow name and before the `on:` block. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
