### PR TITLE
fix docker with fastapi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-# Use a single stage build with FalkorDB base image
+# Multi-stage build: Start with Python 3.12 base
+FROM python:3.12-bookworm as python-base
+
+# Main stage: Use FalkorDB base and copy Python 3.12
 FROM falkordb/falkordb:latest
 
 ENV PYTHONUNBUFFERED=1 \
@@ -7,12 +10,15 @@ ENV PYTHONUNBUFFERED=1 \
 
 USER root
 
-# Install Python and pip, netcat for wait loop in start.sh
+# Copy Python 3.12 from the python base image
+COPY --from=python-base /usr/local /usr/local
+
+# Install netcat for wait loop in start.sh
 RUN apt-get update && apt-get install -y \
-    python3 \
-    python3-pip \
     netcat-openbsd \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -sf /usr/local/bin/python3.12 /usr/bin/python3 \
+    && ln -sf /usr/local/bin/python3.12 /usr/bin/python
 
 WORKDIR /app
 
@@ -25,6 +31,25 @@ COPY Pipfile Pipfile.lock ./
 # Install Python dependencies from Pipfile
 RUN PIP_BREAK_SYSTEM_PACKAGES=1 pipenv sync --system
 
+# Install Node.js (Node 22) so we can build the frontend inside the image.
+# Use NodeSource setup script to get a recent Node version on Debian-based images.
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get update && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy only frontend package files so Docker can cache npm installs when
+# package.json / package-lock.json don't change.
+COPY app/package*.json ./app/
+
+# Install frontend dependencies (reproducible install using package-lock)
+RUN if [ -f ./app/package-lock.json ]; then \
+            npm --prefix ./app ci --no-audit --no-fund; \
+        elif [ -f ./app/package.json ]; then \
+            npm --prefix ./app install --no-audit --no-fund; \
+        else \
+            echo "No frontend package.json found, skipping npm install"; \
+        fi
+
 # Copy application code
 COPY . .
 
@@ -33,7 +58,6 @@ COPY start.sh /start.sh
 RUN chmod +x /start.sh
 
 EXPOSE 5000 6379 3000
-
 
 # Use start.sh as entrypoint
 ENTRYPOINT ["/start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -17,5 +17,14 @@ while ! nc -z "$FALKORDB_HOST" "$FALKORDB_PORT"; do
 done
 
 
-echo "FalkorDB is up - launching Flask..."
-exec python3 -m flask --app api.index run --host=0.0.0.0 --port=5000
+echo "FalkorDB is up - launching FastAPI..."
+# Determine whether to run in reload (debug) mode. The project uses FLASK_DEBUG
+# environment variable historically; keep compatibility by honoring it here.
+if [ "${FLASK_DEBUG:-False}" = "True" ] || [ "${FLASK_DEBUG:-true}" = "true" ]; then
+  RELOAD_FLAG="--reload"
+else
+  RELOAD_FLAG=""
+fi
+
+echo "FalkorDB is up - launching FastAPI (uvicorn)..."
+exec uvicorn api.index:app --host 0.0.0.0 --port 5000 $RELOAD_FLAG


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified container with Python 3.12 and Node 22; supports in-image frontend builds.
  - Explicit startup script as container entrypoint, including readiness checks.
  - Optional auto-reload for development controlled by FLASK_DEBUG.
- Refactor
  - Web service now runs on FastAPI via uvicorn; address/port unchanged (0.0.0.0:5000).
- Chores
  - Multi-stage Docker build streamlines image and reduces redundancy.
  - Improved dependency caching for frontend installs to speed up builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->