### PR TITLE
Set APP_ENV to force HTTPS in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,13 @@ FASTAPI_SECRET_KEY=your_super_secret_key_here
 # Optional: enable debug/reload when running the app directly
 # FASTAPI_DEBUG=False
 
+# Optional: set application environment (development, staging, production)
+# Default: development
+# APP_ENV=development
+
+# Optional: allow OAuth over HTTP in development (disable in production)
+# OAUTHLIB_INSECURE_TRANSPORT=1
+
 # -----------------------------
 # FalkorDB connection (REQUIRED / preferred)
 # -----------------------------
@@ -67,6 +74,17 @@ FALKORDB_URL=redis://localhost:6379/0  # REQUIRED - change to your FalkorDB URL
 # If your OAuth app uses a different base URL than the request base (e.g., using 127.0.0.1 vs localhost)
 # you can override the base used for building callback URLs. Example:
 # OAUTH_BASE_URL=http://localhost:5000
+
+# -----------------------------
+# Email Configuration (optional - for sending invitation emails)
+# -----------------------------
+# MAIL_SERVER=smtp.mailgun.org
+# MAIL_PORT=587
+# MAIL_USE_TLS=True
+# MAIL_USERNAME=your_mail_username
+# MAIL_PASSWORD=your_mail_password
+# MAIL_DEFAULT_SENDER=noreply@yourdomain.com
+# EMAIL_AUTH_ENABLED=false
 
 # -----------------------------
 # Frontend / analytics (optional)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -137,6 +137,10 @@ Create `.env` file from `.env.example` and configure these essential variables:
 # REQUIRED for FastAPI to start
 FASTAPI_SECRET_KEY=your_super_secret_key_here
 
+# Optional: set application environment (development, staging, production)
+# Default: development (affects session cookie security for OAuth)
+APP_ENV=development
+
 # REQUIRED for database connection (preferred)
 # Use a single connection string if possible. Example:
 # FALKORDB_URL=redis://localhost:6379/0
@@ -158,6 +162,7 @@ FASTAPI_SECRET_KEY=your_super_secret_key_here
 **For testing in CI/development**, minimal `.env` setup:
 ```bash
 FASTAPI_SECRET_KEY=test-secret-key
+APP_ENV=development
 FASTAPI_DEBUG=False
 FALKORDB_HOST=localhost
 FALKORDB_PORT=6379

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ If you prefer to pass variables on the command line, use `-e` flags (less conven
 
 ```bash
 docker run -p 5000:5000 -it \
+  -e APP_ENV=production \
   -e FASTAPI_SECRET_KEY=your_super_secret_key_here \
   -e GOOGLE_CLIENT_ID=your_google_client_id \
   -e GOOGLE_CLIENT_SECRET=your_google_client_secret \
@@ -83,7 +84,7 @@ pipenv sync --dev
 
 # Create a local environment file
 cp .env.example .env
-# Edit .env with your values
+# Edit .env with your values (set APP_ENV=development for local development)
 ```
 
 ### Run the app locally
@@ -121,6 +122,20 @@ QueryWeaver supports Google and GitHub OAuth. Create OAuth credentials for each 
 
 - Google: set authorized origin and callback `http://localhost:5000/login/google/authorized`
 - GitHub: set homepage and callback `http://localhost:5000/login/github/authorized`
+
+#### Environment-specific OAuth settings
+
+For production/staging deployments, set `APP_ENV=production` or `APP_ENV=staging` in your environment to enable secure session cookies (HTTPS-only). This prevents OAuth CSRF state mismatch errors.
+
+```bash
+# For production/staging (enables HTTPS-only session cookies)
+APP_ENV=production
+
+# For development (allows HTTP session cookies)
+APP_ENV=development
+```
+
+**Important**: If you're getting "mismatching_state: CSRF Warning!" errors on staging/production, ensure `APP_ENV` is set to `production` or `staging` to enable secure session handling.
 
 ## MCP server: host or connect (optional)
 
@@ -221,6 +236,7 @@ GitHub Actions run unit and E2E tests on pushes and pull requests. Failures capt
 - FalkorDB connection issues: start the DB helper `make docker-falkordb` or check network/host settings.
 - Playwright/browser failures: install browsers with `pipenv run playwright install` and ensure system deps are present.
 - Missing environment variables: copy `.env.example` and fill required values.
+- **OAuth "mismatching_state: CSRF Warning!" errors**: Set `APP_ENV=production` (or `staging`) in your environment for HTTPS deployments, or `APP_ENV=development` for HTTP development environments. This ensures session cookies are configured correctly for your deployment type.
 
 ## Project layout (high level)
 

--- a/api/app_factory.py
+++ b/api/app_factory.py
@@ -58,12 +58,19 @@ def create_app():
     app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
 
     # Add session middleware with explicit settings to ensure OAuth state persists
+    # Detect if we're running on HTTPS (staging/production) vs HTTP (development)
+    app_env = os.getenv("APP_ENV", "").lower()
+    if app_env in ("production", "staging"):
+        is_https = True
+    else:
+        is_https = False
+
     app.add_middleware(
         SessionMiddleware,
         secret_key=SECRET_KEY,
         session_cookie="qw_session",
         same_site="lax",  # allow top-level OAuth GET redirects to send cookies
-        https_only=False,  # allow http on localhost in development
+        https_only=is_https,  # True for HTTPS environments (staging/prod), False for HTTP dev
         max_age=60 * 60 * 24 * 14,  # 14 days - measured by seconds
     )
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -119,6 +119,7 @@ Key environment variables for testing:
 ```bash
 # Required for FastAPI
 FASTAPI_SECRET_KEY=your-secret-key
+APP_ENV=development
 FASTAPI_DEBUG=False
 
 # Database connection (optional for basic tests)


### PR DESCRIPTION
Users are getting this error when trying to login with Google 

```
{"detail":"Authentication failed: mismatching_state: CSRF Warning! State not equal in request and response."} 
```

on staging.queryweaver.ai 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Environment-aware session cookie security via APP_ENV (development, staging, production) for OAuth-related flows.
* Documentation
  * Updated setup guidance to include APP_ENV usage for selecting cookie security modes.
  * Added environment-specific OAuth settings and troubleshooting notes.
  * Updated Docker run example with APP_ENV for production deployments.
  * Clarified local development instructions using APP_ENV=development.
  * Expanded testing docs to list APP_ENV as a key variable.
* Chores
  * Enhanced sample .env with optional APP_ENV and email configuration examples (commented by default).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->