### PR TITLE
Add concurrency settings to Playwright workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [ main, staging ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, staging ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Add concurrency configuration for GitHub Actions.
 
 
 
 
 
 **PR Summary by Typo**
------------

#### Overview:
This PR introduces concurrency settings to the Playwright and general test GitHub Actions workflows. The aim is to optimize CI/CD pipeline efficiency by preventing redundant runs and ensuring only the latest commit's workflow executes for a given pull request or branch.

#### Key Changes:
- Added a `concurrency` block to both `playwright.yml` and `tests.yml` GitHub Actions workflows.
- Configured the concurrency group to uniquely identify runs based on the workflow name and pull request number or branch reference.
- Enabled `cancel-in-progress: true` to automatically cancel any ongoing workflow runs for the same group when a new one is triggered.

#### Work Breakdown

| Category    | Lines Changed |
|-------------|---------------|
| New Work    | 8 (100.0%)    |
| Total Changes | 8             | 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>