### PR TITLE
fix(e2e): read CSRF token from storageState cookies before seeding

### DIFF
--- a/e2e/infra/api/apiRequests.ts
+++ b/e2e/infra/api/apiRequests.ts
@@ -24,11 +24,24 @@ const csrfCache = new WeakMap<APIRequestContext, string>();
 /**
  * Seed the CSRF cookie on the given request context by making a lightweight
  * GET (only on the first call), then return the cached token value.
+ *
+ * When the context already carries the csrf_token cookie (e.g. loaded from
+ * storageState), the server won't emit a new Set-Cookie header.  In that
+ * case we read the token directly from the context's stored cookies.
  */
 async function getCsrfToken(baseUrl: string, ctx: APIRequestContext): Promise<string | undefined> {
   const cached = csrfCache.get(ctx);
   if (cached) return cached;
 
+  // Check if the csrf_token cookie already exists in the context (from storageState)
+  const state = await ctx.storageState();
+  const existingCookie = state.cookies.find(c => c.name === 'csrf_token');
+  if (existingCookie) {
+    csrfCache.set(ctx, existingCookie.value);
+    return existingCookie.value;
+  }
+
+  // No existing cookie — seed it with a lightweight GET request
   const seedResp = await ctx.get(`${baseUrl}/auth-status`);
   const setCookies = seedResp.headersArray()
     .filter(h => h.name.toLowerCase() === 'set-cookie')


### PR DESCRIPTION
## Problem

Playwright E2E tests in CI fail with `"CSRF token missing or invalid"` on all POST/DELETE API calls (database connection tests, chat tests via `ensureDatabaseConnected`).

### Root Cause

The `getCsrfToken()` function in `e2e/infra/api/apiRequests.ts` only extracts the CSRF token from the `Set-Cookie` response header. When the Playwright `request` fixture loads `storageState` (from `e2e/.auth/user.json`), the `csrf_token` cookie is already present. The server's `_ensure_csrf_cookie()` skips emitting a new `Set-Cookie` when it detects the cookie already exists in the request. Result: `getCsrfToken()` returns `undefined`, and the `X-CSRF-Token` header is never sent.

## Fix

Check the context's `storageState()` for an existing `csrf_token` cookie **before** falling back to the seed GET request. This handles both cases:
- **Fresh context** (no storageState): seeds via GET → extracts from Set-Cookie ✅
- **Authenticated context** (storageState loaded): reads existing cookie directly ✅

## Failing CI checks on PR #438
- `Playwright Tests/test (push)` ❌
- `Playwright Tests/test (pull_request)` ❌

## Changes
- `e2e/infra/api/apiRequests.ts`: Modified `getCsrfToken()` to read cookies from `ctx.storageState()` first