### PR TITLE
Clean up remaining pipenv/poetry references after uv migration

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -30,8 +30,6 @@ Nullability
 endcapture
 CVSS
 falkordb
-pipenv
-Pipenv
 uv
 pyproject
 README

--- a/docs/postgres_loader.md
+++ b/docs/postgres_loader.md
@@ -12,15 +12,11 @@ This loader connects to a PostgreSQL database and extracts the complete schema i
 
 ## Installation
 
-{% capture shell_0 %}
-poetry add psycopg2-binary
-{% endcapture %}
+psycopg2-binary is already included in QueryWeaver's dependencies. If you need to add it manually:
 
-{% capture shell_1 %}
-pip install psycopg2-binary
-{% endcapture %}
-
-{% include code_tabs.html id="install_tabs" shell=shell_0 shell2=shell_1 %}
+```bash
+uv add psycopg2-binary
+```
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Post-migration cleanup from the pipenv → uv switch (PR #471).

### Changes
- **`.github/wordlist.txt`**: Remove stale `pipenv`/`Pipenv` entries from spellcheck dictionary
- **`docs/postgres_loader.md`**: Replace `poetry add` / `pip install` install instructions with `uv add`

### Review notes
- The Makefile, CI workflows, Dockerfile, conftest.py, setup_e2e_tests.sh, dependabot.yml, and README are all clean — no remaining pipenv references
- `.claude/settings.local.json` still has a stale `pipenv run` permission but is gitignored, so it's a local-only concern