### PR TITLE
fix: replace unnecessary dynamic import of vendorConfig with static import

### DIFF
--- a/app/src/components/chat/ChatInterface.tsx
+++ b/app/src/components/chat/ChatInterface.tsx
@@ -12,6 +12,7 @@ import QueryInput from "./QueryInput";
 import SuggestionCards from "../SuggestionCards";
 import { ChatService } from "@/services/chat";
 import type { ConfirmRequest } from "@/types/api";
+import { getVendorPrefix } from "@/utils/vendorConfig";
 
 interface ChatMessageData {
   id: string;
@@ -338,7 +339,6 @@ const ChatInterface = ({
       if (isApiKeyValid && apiKey) {
         confirmRequest.custom_api_key = apiKey;
         if (modelName && vendor) {
-          const { getVendorPrefix } = await import('@/utils/vendorConfig');
           const vendorPrefix = getVendorPrefix(vendor);
           confirmRequest.custom_model = modelName.startsWith(`${vendorPrefix}/`)
             ? modelName


### PR DESCRIPTION
## Summary

`vendorConfig.ts` is dynamically imported in `ChatInterface.tsx` but statically imported by four other modules (`SettingsContext`, `useApiKeyValidation`, `Settings`, `chat` service). Since the module is already in the main bundle, the dynamic `import()` provides no code-splitting benefit and produces a Vite build warning.

## Changes

- Converted the dynamic `import()` in `ChatInterface.tsx` to a static import
- Eliminates the Vite build warning with no behavioral change

## Verification

- `make build-dev` completes with a clean output (no warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multi-AI provider support: OpenAI, Google Gemini, Anthropic, Cohere, and Ollama now supported.
  * Per-request custom API key and model configuration.
  * API key validation endpoint.
  * Enhanced Settings page with AI model configuration UI.

* **Refactor**
  * Migrated dependency management from Pipenv to uv.
  * Refactored agent implementations for multi-provider support.

* **Chores**
  * Updated frontend dependencies and GitHub Actions versions.
  * Configuration moved to `pyproject.toml` for Python testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->