### PR TITLE
fix: require SECRET_TOKEN at startup to prevent auth bypass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,10 +42,11 @@ FALKORDB_URL=redis://localhost:6379/0  # REQUIRED - change to your FalkorDB URL
 # FALKORDB_PORT=6379
 
 # -----------------------------
-# Optional API / secret tokens
+# API / secret tokens
 # -----------------------------
-# API token for internal API access (optional)
-# SECRET_TOKEN=your_secret_token
+# REQUIRED: static bearer token for internal / programmatic API access.
+# The server refuses to start when this is missing.
+SECRET_TOKEN=your_secret_token
 # SECRET_TOKEN_ERP=your_erp_token
 
 # -----------------------------

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -136,6 +136,7 @@ jobs:
       env:
         PYTHONUNBUFFERED: 1
         FASTAPI_SECRET_KEY: test-secret-key-for-ci
+        SECRET_TOKEN: test-secret-token-for-ci
         APP_ENV: development
         FASTAPI_DEBUG: False
         FALKORDB_URL: redis://localhost:6379

--- a/api/auth/user_management.py
+++ b/api/auth/user_management.py
@@ -1,6 +1,7 @@
 """User management and authentication functions for text2sql API."""
 
 import base64
+import hmac
 import logging
 import os
 import secrets
@@ -17,6 +18,16 @@ if not SECRET_KEY:
     SECRET_KEY = secrets.token_hex(32)
     logging.warning(
         "FASTAPI_SECRET_KEY not set, using generated key. Set this in production!"
+    )
+
+# Static API token for internal / programmatic access.
+# REQUIRED: the server refuses to start when this is missing so that
+# an unconfigured deployment never silently disables authentication.
+SECRET_TOKEN: str = os.environ.get("SECRET_TOKEN", "")
+if not SECRET_TOKEN:
+    raise RuntimeError(
+        "SECRET_TOKEN environment variable is required but not set. "
+        "Set it to a strong, random value before starting the server."
     )
 
 
@@ -235,11 +246,22 @@ async def validate_user(request: Request) -> Tuple[Optional[Dict[str, Any]], boo
     try:
         api_token = get_token(request)
 
-        if api_token:
-            db_info = await _get_user_info(api_token)
+        if not api_token:
+            return None, False
 
-            if db_info:
-                return db_info, True
+        # Accept the static SECRET_TOKEN for internal / programmatic access.
+        # Uses constant-time comparison to prevent timing attacks.
+        if hmac.compare_digest(api_token, SECRET_TOKEN):
+            return {
+                "email": "api@internal",
+                "name": "API",
+                "picture": None,
+            }, True
+
+        db_info = await _get_user_info(api_token)
+
+        if db_info:
+            return db_info, True
 
         return None, False
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,10 @@ import os
 import subprocess
 import time
 
+# SECRET_TOKEN must be set before any test imports api.index (which triggers
+# app creation and the startup SECRET_TOKEN requirement check).
+os.environ.setdefault("SECRET_TOKEN", "test-secret-token")
+
 import pytest
 import requests
 
@@ -27,6 +31,7 @@ def fastapi_app():
         'GOOGLE_CLIENT_SECRET': 'test-google-client-secret',
         'GITHUB_CLIENT_ID': 'test-github-client-id',
         'GITHUB_CLIENT_SECRET': 'test-github-client-secret',
+        'SECRET_TOKEN': 'test-secret-token',
         'ENABLE_TEST_AUTH': 'true',  # Enable test auth bypass for E2E tests
     }
     for var, default in env_defaults.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,8 @@ import time
 # app creation and the startup SECRET_TOKEN requirement check).
 os.environ.setdefault("SECRET_TOKEN", "test-secret-token")
 
-import pytest
-import requests
+import pytest  # pylint: disable=wrong-import-position
+import requests  # pylint: disable=wrong-import-position
 
 
 def pytest_configure(config):


### PR DESCRIPTION
## Summary
- The original `verify_token()` (from the Flask era) allowed `None == None` when `SECRET_TOKEN` was unset, silently disabling authentication for every route
- The server now **refuses to start** without `SECRET_TOKEN` configured (`RuntimeError` at import time)
- `validate_user()` accepts the static `SECRET_TOKEN` as a valid bearer token via `hmac.compare_digest` (constant-time), as an alternative to DB-backed OAuth tokens
- `.env.example` updated to mark `SECRET_TOKEN` as required
- Test `conftest.py` sets `SECRET_TOKEN` via `os.environ.setdefault` before app import

## Test plan
- [x] All 19 existing tests pass (`test_csrf_middleware`, `test_hsts_header`)
- [x] Server refuses to start when `SECRET_TOKEN` is not set
- [x] Server starts normally when `SECRET_TOKEN` is set
- [ ] Verify `Bearer <SECRET_TOKEN>` authenticates successfully against a protected endpoint
- [ ] Verify invalid bearer tokens are still rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * SECRET_TOKEN is now required; the server will refuse to start if it is not set.

* **New Features**
  * Internal API token authentication added to authorize internal requests.

* **Tests**
  * Test and CI setup updated to supply a default SECRET_TOKEN so test and CI startups succeed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->