### PR TITLE
fix: Address PR #455 review comments

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
       with:
-        version: "latest"
+        version: "0.7.12"
 
     # Setup Node.js
     - uses: actions/setup-node@v6
@@ -49,7 +49,7 @@ jobs:
 
     # Install Python dependencies
     - name: Install Python dependencies
-      run: uv sync
+      run: uv sync --locked
     
     # Install Node dependencies (root - for Playwright)
     - name: Install root dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,11 +39,11 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
       with:
-        version: "latest"
+        version: "0.7.12"
 
     - name: Install dependencies
       run: |
-        uv sync
+        uv sync --locked
 
     - name: Install frontend dependencies
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ ENV UV_SYSTEM_PYTHON=1
 # Ensure venv binaries are on PATH (uv sync always creates .venv)
 ENV PATH="/app/.venv/bin:$PATH"
 
-# Install Python dependencies from pyproject.toml
-RUN uv sync --frozen --no-dev
+# Install Python dependencies only (project itself installed after COPY)
+RUN uv sync --frozen --no-dev --no-install-project
 
 # Install Node.js (Node 22) so we can build the frontend inside the image.
 # Use NodeSource setup script to get a recent Node version on Debian-based images.
@@ -74,6 +74,9 @@ RUN npm --prefix ./app run build
 
 # Copy application code 
 COPY . .
+
+# Install the project package now that source code is available
+RUN uv sync --frozen --no-dev
 
 # Copy and make start.sh executable
 COPY start.sh /start.sh

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test-e2e-debug: build-dev ## Run E2E tests with debugging enabled
 
 lint: ## Run linting (backend + frontend)
 	@echo "Running backend lint (pylint)"
-	uv run python -m pylint $(shell git ls-files '*.py') || true
+	uv run python -m pylint $(shell git ls-files '*.py')
 	@echo "Running frontend lint (eslint)"
 	make lint-frontend
 

--- a/api/config.py
+++ b/api/config.py
@@ -70,10 +70,6 @@ class Config:
     Configuration class for the text2sql module.
     """
 
-    # Provider flag: "azure", "openai", "gemini", "anthropic", "ollama", "cohere"
-    LLM_PROVIDER = "azure"
-    AZURE_FLAG = True
-
     # User-provided overrides via env vars
     _user_completion = os.getenv("COMPLETION_MODEL", "")
     _user_embedding = os.getenv("EMBEDDING_MODEL", "")

--- a/docs/postgres_loader.md
+++ b/docs/postgres_loader.md
@@ -13,10 +13,10 @@ This loader connects to a PostgreSQL database and extracts the complete schema i
 
 ## Installation
 
-psycopg2-binary is already included in QueryWeaver's dependencies. If you need to add it manually:
+psycopg2-binary is already included in QueryWeaver's dependencies. Install project dependencies with:
 
 ```bash
-uv add psycopg2-binary
+uv sync
 ```
 
 ## Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,11 @@ filterwarnings = [
 ]
 
 [tool.pylint.main]
-max-line-length = 120
 disable = [
     "C0114",  # missing-module-docstring
     "C0115",  # missing-class-docstring
     "C0116",  # missing-function-docstring
 ]
+
+[tool.pylint.format]
+max-line-length = 120


### PR DESCRIPTION
## Summary

Addresses valid review comments from PR #455 (Staging→Main).

### Changes

| File | Fix |
|------|-----|
| `.github/workflows/tests.yml` | Pin uv to v0.7.12, use `uv sync --locked` for reproducible CI |
| `.github/workflows/playwright.yml` | Same uv pinning + `--locked` |
| `Dockerfile` | Split uv sync: `--no-install-project` for deps layer, second sync after `COPY . .` |
| `Makefile` | Remove `|| true` from pylint so lint failures are not masked |
| `pyproject.toml` | Move `max-line-length` to `[tool.pylint.format]` (canonical Pylint 4 section) |
| `docs/postgres_loader.md` | Use `uv sync` instead of `uv add` for already-declared deps |
| `api/config.py` | Remove dead initial `LLM_PROVIDER`/`AZURE_FLAG` assignments |

### Review Comments Resolved

Outdated/irrelevant comments on PR #455 have been resolved (16 outdated threads + 1 invalid finding about package-lock.json workspace reference that doesn't exist).

Relates to #455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PostgreSQL loader installation instructions for clarity.

* **Chores**
  * Optimized CI/CD workflows and Docker build processes for improved reliability.
  * Updated development tooling configurations for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->