### PR TITLE
fix: require authentication on validate-api-key endpoint

### DIFF
--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -6,6 +6,8 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from litellm import completion
 
+from api.auth.user_management import token_required
+
 settings_router = APIRouter(tags=["Settings"])
 
 
@@ -22,13 +24,13 @@ class ValidateKeyRequest(BaseModel):
 
 
 @settings_router.post("/validate-api-key")
+@token_required
 async def validate_api_key(request: Request, data: ValidateKeyRequest):  # pylint: disable=too-many-return-statements
     """
     Validate an AI provider API key by making a simple test request.
     This endpoint does not store the key, it only validates it.
     Supports: openai, google, anthropic
     """
-    _ = request
     api_key = data.api_key.strip()
     vendor = data.vendor.lower()
     model = data.model

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from litellm import completion
 
 from api.auth.user_management import token_required
+from api.routes.tokens import UNAUTHORIZED_RESPONSE
 
 settings_router = APIRouter(tags=["Settings"])
 
@@ -23,7 +24,7 @@ class ValidateKeyRequest(BaseModel):
     model: str = "gpt-3.5-turbo"
 
 
-@settings_router.post("/validate-api-key")
+@settings_router.post("/validate-api-key", responses={401: UNAUTHORIZED_RESPONSE})
 @token_required
 async def validate_api_key(request: Request, data: ValidateKeyRequest):  # pylint: disable=too-many-return-statements,unused-argument
     """

--- a/api/routes/settings.py
+++ b/api/routes/settings.py
@@ -25,7 +25,7 @@ class ValidateKeyRequest(BaseModel):
 
 @settings_router.post("/validate-api-key")
 @token_required
-async def validate_api_key(request: Request, data: ValidateKeyRequest):  # pylint: disable=too-many-return-statements
+async def validate_api_key(request: Request, data: ValidateKeyRequest):  # pylint: disable=too-many-return-statements,unused-argument
     """
     Validate an AI provider API key by making a simple test request.
     This endpoint does not store the key, it only validates it.


### PR DESCRIPTION
## Summary
- Adds `@token_required` decorator to `POST /api/validate-api-key` endpoint, which was the only POST endpoint missing authentication
- Without this, unauthenticated users could use the server as a proxy to validate arbitrary API keys against LLM providers

## Test plan
- [ ] Verify `POST /api/validate-api-key` returns 401 when called without a valid session/token
- [ ] Verify the Settings page "Save & Validate" button still works for authenticated users
- [ ] Confirm no other endpoints were affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * API key validation endpoint now requires authentication.
  * Unauthorized requests now return an explicit 401 response status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->