### PR TITLE
ci(playwright): skip E2E tests for Dependabot PRs

### DIFF
--- a/.github/wordlist.txt
+++ b/.github/wordlist.txt
@@ -118,3 +118,4 @@ pylint
 pytest
 Radix
 Zod
+Dependabot

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,6 +19,10 @@ env:
 
 jobs:
   test:
+    # Skip for Dependabot PRs — the LLM-dependent E2E tests require Azure OpenAI
+    # secrets that are not available in Dependabot PR runs. Full E2E coverage runs
+    # on the merge-to-staging/main push event where secrets are accessible.
+    if: github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'
     timeout-minutes: 60
     runs-on: ubuntu-latest
     

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ See `.env.example` for the full list.
 
 GitHub Actions workflows (`.github/workflows/`):
 - **tests.yml** — unit tests + lint on push/PR to main/staging
-- **playwright.yml** — dedicated Playwright E2E suite
+- **playwright.yml** — dedicated Playwright E2E suite (skipped for Dependabot PRs; secrets unavailable)
 - **pylint.yml** — Python linting
 - **spellcheck.yml** — docs spellcheck
 - **publish-docker.yml** — build & push Docker image to DockerHub


### PR DESCRIPTION
## Summary
Skip Playwright E2E tests for Dependabot-authored PRs since repository secrets (Azure OpenAI API keys) are not available in Dependabot PR runs.

## Changes
- Added `if` condition to the `test` job in `.github/workflows/playwright.yml`
- Condition: `github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]'`
- Push events (merge to staging/main) are unaffected — full E2E coverage runs there

## Testing
- Verified YAML syntax is valid
- Condition logic: skips only for `pull_request` events from `dependabot[bot]`, preserves push events and regular PRs
- All other CI checks (unit tests, pylint, dependency review, spellcheck) remain unchanged

## Memory / Performance Impact
N/A — CI workflow change only.

## Related Issues
Fixes persistent Playwright failures on all Dependabot PRs:
- #508 (pytest bump)
- tailwind-merge, fastapi, npm_and_yarn Dependabot PRs all exhibit the same failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow now skips the Playwright end-to-end test job for automated dependency-update pull requests.
  * Project wordlist updated to include "Dependabot" and ensure file newline consistency.

* **Documentation**
  * CI docs updated to state the Playwright E2E suite is intentionally skipped on those automated PRs due to unavailable secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->