### PR TITLE
fix(docker): resolve apt dependency errors on falkordb trixie base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ COPY --from=python-base /usr/local /usr/local
 
 # Install netcat for wait loop in start.sh and system build tools needed for
 # compiling Python wheels (g++, make, libc-dev)
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends libtinfo6 \
+    && apt-get install -y --no-install-recommends \
+    bash \
     netcat-openbsd \
     git \
     build-essential \


### PR DESCRIPTION
## Summary
Docker build was failing with apt unmet-dependency errors on the FalkorDB base image (now Debian trixie).

## Changes
- Install `libtinfo6` in a separate `apt-get install` step so the trixie apt 3.0 solver can resolve `util-linux`'s PreDepends and stop refusing to install `build-essential`, `curl`, `git`, `gnupg`.
- Add `bash` to the package list so the NodeSource `setup_22.x` script can run (`falkordb/falkordb:latest` ships without bash).

## Testing
`docker build -t qw-test .` — completes successfully.

## Memory / Performance Impact
Negligible (two extra small packages).

## Related Issues
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker image dependency installation by ensuring proper library availability during the build process, resulting in more reliable image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->