### PR TITLE
fix: address AI review findings on staging promotion (#582)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,10 +111,10 @@ jobs:
           --health-retries 5
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: '3.12'
 

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -116,8 +116,12 @@ def _verify_password(password: str, stored_password_hex: str) -> bool:
 def _sanitize_for_log(value: str) -> str:
     """Sanitize user input for logging by removing newlines and carriage returns."""
     if not isinstance(value, str):
-        return str(value)
-    return value.replace('\r\n', '').replace('\n', '').replace('\r', '')
+        value = str(value)
+    # Strip carriage returns first, then newlines. The final ``.replace('\n', '')``
+    # must be the outermost (returned) call so that CodeQL's log-injection sanitizer
+    # (ReplaceLineBreaksSanitizer, which only recognises a first argument of "\n" or
+    # "\r\n") treats the returned value as sanitised.
+    return value.replace('\r', '').replace('\n', '')
 
 def _validate_email(email: str) -> bool:
     """Basic email validation."""

--- a/api/routes/auth.py
+++ b/api/routes/auth.py
@@ -116,7 +116,12 @@ def _verify_password(password: str, stored_password_hex: str) -> bool:
 def _sanitize_for_log(value: str) -> str:
     """Sanitize user input for logging by removing newlines and carriage returns."""
     if not isinstance(value, str):
-        value = str(value)
+        try:
+            value = str(value)
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Defensive: a custom __str__ may raise. Log sanitisation must never
+            # be fatal to the auth flow, so fall back to a safe placeholder.
+            return '<unprintable>'
     # Strip carriage returns first, then newlines. The final ``.replace('\n', '')``
     # must be the outermost (returned) call so that CodeQL's log-injection sanitizer
     # (ReplaceLineBreaksSanitizer, which only recognises a first argument of "\n" or


### PR DESCRIPTION
## What

Addresses the two AI-review findings raised on the staging→main promotion PR #582.

### 1. CodeQL `py/log-injection` (alerts 251, 252, 253) — `api/routes/auth.py`
The three flagged log statements already route the email through `_sanitize_for_log`, but CodeQL still reported them. CodeQL's `ReplaceLineBreaksSanitizer` only recognises a `.replace(...)` call whose **first argument is `"\n"` or `"\r\n"`**. The helper's outermost (returned) call was `.replace('\r', '')` (first arg `"\r"`), so CodeQL did not treat the returned value as sanitised.

Fix: reorder so the returned value comes from `.replace('\n', '')`:

```python
return value.replace('\r', '').replace('\n', '')
```

Behaviour is unchanged — all `\r`, `\n`, and `\r\n` sequences are still stripped (verified). This clears all three alerts and every other call site that uses the helper.

### 2. CI supply-chain hardening (overcut-ai, major) — `.github/workflows/tests.yml`
The `sdk-tests` job used floating tags `actions/checkout@v6` / `actions/setup-python@v6` while the `unit-tests` job pins them to commit SHAs. Pinned both to the **same SHAs already used by `unit-tests`** for consistent, reproducible CI.

## Testing
- `_sanitize_for_log` verified to strip all CR/LF combinations.
- `tests.yml` validated as well-formed YAML; `py_compile` clean on `auth.py`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log sanitization to prevent log injection and handle non-string or unprintable inputs safely.
  * Enhanced authentication logging to better manage edge-case inputs.

* **Chores**
  * CI workflow updated to pin build steps to specific commits for more stable and reproducible builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->