### PR TITLE
fix: resolve all CodeQL code quality findings

### DIFF
--- a/api/memory/graphiti_tool.py
+++ b/api/memory/graphiti_tool.py
@@ -388,7 +388,7 @@ class MemoryTool:
 
             # Execute the Cypher query through Graphiti's graph driver
             try:
-                result = await graph_driver.execute_query(cypher_query, embedding=embeddings)
+                await graph_driver.execute_query(cypher_query, embedding=embeddings)
                 return True
             except Exception as cypher_error:
                 logging.error("Error executing Cypher query: %s", cypher_error)

--- a/app/src/components/schema/SchemaViewer.tsx
+++ b/app/src/components/schema/SchemaViewer.tsx
@@ -386,7 +386,7 @@ const SchemaViewer = ({ isOpen, onClose, onWidthChange, sidebarWidth = 64 }: Sch
       <div
         data-testid="schema-panel"
         className={`fixed top-0 h-full bg-background border-r border-border flex flex-col transition-all duration-300
-          ${isOpen ? 'translate-x-0' : '-translate-x-full pointer-events-none'}
+          translate-x-0
           md:z-30 z-50
           w-[80vw] max-w-[400px] md:max-w-none
         `}

--- a/app/src/pages/Index.tsx
+++ b/app/src/pages/Index.tsx
@@ -34,7 +34,7 @@ const Index = () => {
   const [showSchemaViewer, setShowSchemaViewer] = useState(false);
   const [showTokensModal, setShowTokensModal] = useState(false);
   // userRulesSpec is now fetched from the graph database per query
-  const [useMemory, setUseMemory] = useState(() => {
+  const [useMemory] = useState(() => {
     // Load from localStorage on init, default to true
     if (typeof window !== 'undefined') {
       const saved = localStorage.getItem('queryweaver_use_memory');
@@ -42,7 +42,7 @@ const Index = () => {
     }
     return true;
   });
-  const [useRulesFromDatabase, setUseRulesFromDatabase] = useState(() => {
+  const [useRulesFromDatabase] = useState(() => {
     // Load from localStorage on init, default to false
     if (typeof window !== 'undefined') {
       const saved = localStorage.getItem('queryweaver_use_rules_from_database');
@@ -147,10 +147,6 @@ const Index = () => {
   const handleConnectDatabase = () => {
     if (isRefreshingSchema || isChatProcessing) return;
     setShowDatabaseModal(true);
-  };
-
-  const handleUploadSchema = () => {
-    fileInputRef.current?.click();
   };
 
   const handleFileSelect = async (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -61,7 +61,7 @@ const Settings = () => {
   const [githubStars, setGithubStars] = useState<string>('-');
   const [appVersion, setAppVersion] = useState<string | null>(null);
   const [rules, setRules] = useState('');
-  const [isLoadingRules, setIsLoadingRules] = useState(true);
+  const [, setIsLoadingRules] = useState(true);
   const [initialRulesLoaded, setInitialRulesLoaded] = useState(false);
   const loadedRulesRef = useRef<string>(''); // Track the originally loaded rules
   const currentRulesRef = useRef<string>(''); // Track the current rules value

--- a/e2e/infra/ui/browserWrapper.ts
+++ b/e2e/infra/ui/browserWrapper.ts
@@ -52,7 +52,7 @@ export default class BrowserWrapper {
             this.page = await this.context.newPage();
         }
         if (url) {
-            await this.navigateTo(url)
+            await this.navigateTo(url);
         }
 
         const pageInstance = new PageClass(this.page);

--- a/e2e/logic/pom/homePage.ts
+++ b/e2e/logic/pom/homePage.ts
@@ -1,4 +1,4 @@
-import { Locator, Page } from "@playwright/test";
+import { Locator } from "@playwright/test";
 import { waitForElementToBeVisible, waitForElementToBeEnabled } from "../../infra/utils";
 import BasePage from "../../infra/ui/basePage";
 import ApiCalls from "../api/apiCalls";


### PR DESCRIPTION
## Summary

Fixes **all 8 open Code Quality findings** reported by CodeQL on the [Code quality](https://github.com/FalkorDB/QueryWeaver/security/quality) page. All changes are minimal and behavior-preserving (dead-code / unused-symbol cleanup + one missing semicolon).

## Findings addressed

| # | Rule | Location | Fix |
|---|------|----------|-----|
| 20 | `py/unused-local-variable` | `api/memory/graphiti_tool.py` | Drop unused `result =` assignment; keep the awaited call |
| 2 | `js/unused-local-variable` | `app/src/pages/Index.tsx` | Remove unused `setUseMemory` setter (value still used) |
| 3 | `js/unused-local-variable` | `app/src/pages/Index.tsx` | Remove unused `setUseRulesFromDatabase` setter (value still used) |
| 4 | `js/unused-local-variable` | `app/src/pages/Index.tsx` | Remove unused `handleUploadSchema` function (no callers) |
| 26 | `js/unused-local-variable` | `app/src/pages/Settings.tsx` | Elide unused `isLoadingRules` value binding (setter still used) |
| 6 | `js/unused-local-variable` | `e2e/logic/pom/homePage.ts` | Remove unused `Page` import |
| 8 | `js/trivial-conditional` | `app/src/components/schema/SchemaViewer.tsx` | `isOpen` is always `true` here (guarded by `if (!isOpen) return null;` above), so simplify the ternary to `translate-x-0` |
| 7 | `js/automatic-semicolon-insertion` | `e2e/infra/ui/browserWrapper.ts` | Add explicit semicolon after `await this.navigateTo(url)` |

## Validation
- `make lint-frontend` (ESLint) — ✅ clean
- `make build-prod` (vite build) — ✅ succeeds
- `uv run pylint $(git ls-files '*.py')` — ✅ 10.00/10
- `npx playwright test --list` — ✅ all 65 e2e tests load (e2e TS changes valid)

No functional behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema sidebar positioning when opened, keeping its layout consistent.
  * Streamlined query/settings toggles and schema upload behavior to better preserve saved preferences and ensure actions trigger reliably.
* **Chores / Tests**
  * Made small code cleanups in automated browser/page and query handling to reduce potential edge-case behavior and keep tooling tidy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->