### PR TITLE
fix(deps): sync root package-lock with react-resizable-panels@4.12.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
         "react-day-picker": "^10.0.1",
         "react-dom": "^19.2.7",
         "react-hook-form": "^7.71.2",
-        "react-resizable-panels": "^4.11.2",
+        "react-resizable-panels": "^4.12.2",
         "react-router-dom": "^7.18.1",
         "recharts": "^2.15.4",
         "sonner": "^1.7.4",
@@ -9988,9 +9988,9 @@
       }
     },
     "node_modules/react-resizable-panels": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.12.1.tgz",
-      "integrity": "sha512-ElE/UpOvMLRWtAqbCgyizHXcbws8RPMyN3cBqmdY17Nxr5f01+DEwzOLqhgcy68GSnjtIUFgKWKl8aIgx5aypQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-4.12.2.tgz",
+      "integrity": "sha512-NwY5LCo4WrxVvDh0xoMML6EMLPONP/8ckKcIdpnojxexoatZdjLiRqLJQjQK5CPkd4SYiB/2M5BVrjZBQtOO7Q==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",


### PR DESCRIPTION
## Problem

The **Playwright Tests** workflow is failing on `staging` (both push and PR events) at the **Install root dependencies** step:

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and package-lock.json are in sync.
npm error Invalid: lock file's react-resizable-panels@4.12.1 does not satisfy react-resizable-panels@4.12.2
```

PR #641 bumped `react-resizable-panels` to `^4.12.2` in `app/package.json` and `app/package-lock.json`, but the **root** `package-lock.json` was not regenerated. The root package links the frontend via `queryweaver-app: file:app`, so it embeds the app dependency tree — which was left pinned at `4.12.1` / spec `^4.11.2`.

## Fix

Regenerate the root `package-lock.json` so the embedded app tree matches `app/package.json`. Minimal 4-line diff:
- spec `^4.11.2` → `^4.12.2`
- resolved `4.12.1` → `4.12.2` (+ integrity)

## Verification

Replicated the failing CI steps locally:
- ✅ `npm ci` at root (previously failing) now passes
- ✅ `npm ci` in `app/` passes
- ✅ `npm run build` (Vite) succeeds

Since `npm ci` validates the `file:app` embedded tree against `app/package.json`, a passing root install also confirms no other app-dependency drift remains.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>