### PR TITLE
fix(security): detect destructive ops in CTEs/stacked SQL (confirmation bypass)

### DIFF
--- a/api/core/pipeline.py
+++ b/api/core/pipeline.py
@@ -213,7 +213,7 @@ _DIALECT_BY_DB_TYPE = {
 _DESTRUCTIVE_EXP_NAMES = frozenset({
     "Insert", "Update", "Delete", "Merge", "Drop", "Create", "Alter",
     "AlterTable", "TruncateTable", "Truncate", "Copy", "Grant", "Revoke",
-    "Into",
+    "Into", "Comment",
 })
 
 # sqlglot expression class name → short verb for the confirmation message.

--- a/api/core/pipeline.py
+++ b/api/core/pipeline.py
@@ -208,12 +208,25 @@ _DIALECT_BY_DB_TYPE = {
 }
 
 # sqlglot expression class names that represent a write, DDL, privilege change,
-# bulk load, or ``SELECT ... INTO``. Any of these anywhere in the parse tree
-# (including inside CTEs and subqueries) makes the whole statement destructive.
+# bulk load, or ``SELECT ... INTO``. These make a statement destructive when
+# they appear anywhere in the parse tree — including nested in a CTE or subquery
+# under an otherwise read-only root (a data-modifying CTE).
 _DESTRUCTIVE_EXP_NAMES = frozenset({
     "Insert", "Update", "Delete", "Merge", "Drop", "Create", "Alter",
     "AlterTable", "TruncateTable", "Truncate", "Copy", "Grant", "Revoke",
     "Into", "Comment",
+})
+
+# Root expression class names that are read-only. Detection is FAIL-CLOSED: a
+# parsed statement is non-destructive only if its root is one of these AND it
+# contains no nested mutation node. Any other root — writes/DDL, a generic
+# ``Command``, or a statement sqlglot models as an unexpected node (e.g.
+# ``Alias``/``Column`` for ``RESET``/``SHUTDOWN``, ``Undrop`` for ``UNDROP``) —
+# is treated as destructive. ``Set`` is intentionally excluded so
+# ``SET GLOBAL``/``SET PERSIST`` cannot slip through; the Text2SQL agents do not
+# emit bare ``SET`` for data questions.
+_READONLY_ROOT_NAMES = frozenset({
+    "Select", "Union", "Intersect", "Except", "Values", "Show", "Describe",
 })
 
 # sqlglot expression class name → short verb for the confirmation message.
@@ -224,42 +237,16 @@ _EXP_NAME_TO_VERB = {
     "Grant": "GRANT", "Revoke": "REVOKE", "Into": "SELECT ... INTO",
 }
 
-# Reported as ``sql_type`` when a statement cannot be parsed and is therefore
-# treated as destructive out of caution.
+# Reported as ``sql_type`` when a statement is destructive but no specific verb
+# can be named (unparseable, or an opaque/unexpected root).
 _UNKNOWN_DESTRUCTIVE_TYPE = "UNKNOWN"
 
-
-# Opening marker of a MySQL/MariaDB "executable comment" (``/*! ...``,
-# ``/*!50110 ...``, ``/*M! ...``): the server RUNS the payload, so we must not
-# let it be discarded as an ordinary comment before parsing.
-_EXECUTABLE_COMMENT_OPEN = re.compile(r"/\*(?:!|M!)\d*")
-
-
-def _unwrap_executable_comments(sql: str) -> str:
-    """Inline the payload of MySQL/MariaDB executable comments.
-
-    sqlglot treats ``/*! ... */`` as an ordinary comment and drops its
-    contents, but MySQL/MariaDB execute that payload. Rewriting the markers to
-    whitespace exposes the payload (e.g. ``/*! DROP TABLE users */`` →
-    `` DROP TABLE users ``) so the destructive statement is actually parsed.
-    """
-    result = []
-    pos = 0
-    while True:
-        match = _EXECUTABLE_COMMENT_OPEN.search(sql, pos)
-        if match is None:
-            result.append(sql[pos:])
-            break
-        close = sql.find("*/", match.end())
-        if close == -1:
-            result.append(sql[pos:])
-            break
-        result.append(sql[pos:match.start()])
-        result.append(" ")
-        result.append(sql[match.end():close])
-        result.append(" ")
-        pos = close + 2
-    return "".join(result)
+# MySQL/MariaDB executable-comment marker (``/*! ...``, ``/*M! ...``). The
+# server RUNS the payload, but sqlglot discards it as an ordinary comment. A
+# comment/string-blind textual rewrite cannot expose it safely (markers can hide
+# inside string literals and mispair with an unrelated ``*/``), so for MySQL we
+# fail safe on the marker's mere presence.
+_EXECUTABLE_COMMENT_MARKER = re.compile(r"/\*M?!")
 
 
 def _sqlglot_dialect(db_type: Optional[str]) -> Optional[str]:
@@ -269,68 +256,76 @@ def _sqlglot_dialect(db_type: Optional[str]) -> Optional[str]:
     return _DIALECT_BY_DB_TYPE.get(db_type.strip().lower())
 
 
+def _root_destructive_verb(statement: Any, root_name: str) -> str:
+    """Name the operation for a destructive (non read-only) statement root."""
+    if root_name in _EXP_NAME_TO_VERB:
+        return _EXP_NAME_TO_VERB[root_name]
+    if root_name == "Command" and statement.this:
+        return str(statement.this).strip().upper() or _UNKNOWN_DESTRUCTIVE_TYPE
+    return _UNKNOWN_DESTRUCTIVE_TYPE
+
+
+def _parse_statements_or_none(sql_query: str, dialect: Optional[str]) -> Optional[list]:
+    """Parse *sql_query* into a list of sqlglot statements.
+
+    Returns ``None`` when the statement must be treated as destructive without
+    inspection: a MySQL executable-comment marker is present (sqlglot silently
+    drops its server-executed payload), or the SQL cannot be parsed at all.
+    """
+    if dialect in (None, "mysql") and _EXECUTABLE_COMMENT_MARKER.search(sql_query):
+        return None
+    sqlglot_logger = logging.getLogger("sqlglot")
+    previous_level = sqlglot_logger.level
+    # Quiet sqlglot's expected "unsupported syntax" warnings only for our parse,
+    # without mutating the "sqlglot" logger globally at import time.
+    sqlglot_logger.setLevel(logging.ERROR)
+    try:
+        return [stmt for stmt in sqlglot.parse(sql_query, read=dialect) if stmt is not None]
+    except Exception:  # pylint: disable=broad-exception-caught
+        return None
+    finally:
+        sqlglot_logger.setLevel(previous_level)
+
+
 def detect_destructive_operation(
     sql_query: Optional[str], db_type: Optional[str] = None
 ) -> tuple[str, bool]:
     """Return ``(sql_type, is_destructive)`` for a SQL statement.
 
     Parses *sql_query* with sqlglot (dialect-aware when *db_type* is given) and
-    inspects the full AST, so classification is not fooled by anything that
-    hides a write behind the first token:
-
-    - data-modifying CTEs — ``WITH t AS (...) DELETE FROM users ...`` and
-      ``WITH t AS (DELETE FROM users ...) SELECT * FROM t``
-    - stacked statements — ``SELECT 1; DROP TABLE users``
-    - MySQL/MariaDB executable comments — ``/*! DROP TABLE users */``
-    - dialect-specific string/comment escapes (backslash escapes, dollar
-      quoting, ``#`` comments) that a hand-rolled scanner mis-tokenises
-
-    Any write (INSERT/UPDATE/DELETE/MERGE/REPLACE), DDL (CREATE/DROP/ALTER/
-    TRUNCATE/RENAME), privilege change (GRANT/REVOKE), bulk load (COPY/LOAD),
-    ``SELECT ... INTO``, or generically-parsed command marks the statement
+    classifies FAIL-CLOSED: a statement is non-destructive only if it parses,
+    every statement's root is a known read-only type (SELECT / set operation /
+    VALUES / SHOW / DESCRIBE), and no nested node is a write/DDL/privilege/bulk
+    operation. Everything else — writes and DDL (including data-modifying CTEs,
+    ``SELECT ... INTO``, ``MERGE``, ``REPLACE``, ``GRANT``/``REVOKE``,
+    ``COPY``/``LOAD``, ``RENAME``, ``CALL``, ``DO``), stacked statements,
+    generically-parsed commands (``RESET``, ``SHUTDOWN``, ``UNDROP``, ...),
+    MySQL executable comments, and anything sqlglot cannot parse — is treated as
     destructive so it cannot bypass the confirmation prompt or the demo-graph
-    read-only guard. The reported ``sql_type`` names the operation for the
-    confirmation message.
+    read-only guard. The reported ``sql_type`` names the operation when known.
 
-    The check is conservative: a statement sqlglot cannot parse is treated as
-    destructive rather than executed unconfirmed.
+    Note: a routine with side effects that is shaped like a read (e.g.
+    ``SELECT setval(...)`` / ``SELECT my_mutating_func()``) is indistinguishable
+    from a pure read by SQL shape alone and is NOT caught here; enforce that with
+    database-level read-only transactions/credentials.
     """
     if not sql_query or not sql_query.strip():
         return "", False
-    prepared = _unwrap_executable_comments(sql_query)
-    # sqlglot logs a WARNING when it falls back to a generic Command for syntax
-    # it does not model (e.g. REPLACE INTO, CALL). That fallback is expected and
-    # handled below, so quiet those warnings only for the duration of our parse
-    # instead of mutating the "sqlglot" logger globally at import time.
-    sqlglot_logger = logging.getLogger("sqlglot")
-    previous_level = sqlglot_logger.level
-    sqlglot_logger.setLevel(logging.ERROR)
-    try:
-        statements = [
-            stmt
-            for stmt in sqlglot.parse(prepared, read=_sqlglot_dialect(db_type))
-            if stmt is not None
-        ]
-    except Exception:  # pylint: disable=broad-exception-caught
-        # Unparseable → we cannot prove it is read-only → require confirmation.
+    statements = _parse_statements_or_none(sql_query, _sqlglot_dialect(db_type))
+    if statements is None:
+        # Executable comment or unparseable → cannot prove read-only → confirm.
         return _UNKNOWN_DESTRUCTIVE_TYPE, True
-    finally:
-        sqlglot_logger.setLevel(previous_level)
     if not statements:
         return "", False
     for statement in statements:
+        root_name = type(statement).__name__
+        if root_name not in _READONLY_ROOT_NAMES:
+            return _root_destructive_verb(statement, root_name), True
         for node in statement.walk():
             node = node[0] if isinstance(node, tuple) else node
             name = type(node).__name__
             if name in _DESTRUCTIVE_EXP_NAMES:
                 return _EXP_NAME_TO_VERB.get(name, name.upper()), True
-            # A statement sqlglot cannot model structurally falls back to a
-            # generic Command (REPLACE INTO, CALL, RENAME, DO, LOAD, VACUUM,
-            # EXPLAIN ANALYZE ...). We cannot prove these are read-only, so treat
-            # them as destructive, named by their leading keyword.
-            if name == "Command":
-                keyword = str(node.this).strip().upper() if node.this else ""
-                return keyword or "COMMAND", True
     return type(statements[0]).__name__.upper(), False
 
 

--- a/api/core/pipeline.py
+++ b/api/core/pipeline.py
@@ -211,17 +211,96 @@ def _strip_sql_comments_and_whitespace(sql_query: str) -> str:
     return text
 
 
+def _skip_quoted(sql: str, start: int, quote: str) -> int:
+    """Return the index just past the quoted span that begins at *start*.
+
+    Handles the SQL doubled-quote escape (``''``, ``""``) so an escaped quote
+    does not prematurely end the span. An unterminated quote consumes the rest
+    of the string. Used to ignore string literals and quoted identifiers when
+    scanning for SQL keywords.
+    """
+    length = len(sql)
+    i = start + 1
+    while i < length:
+        if sql[i] == quote:
+            if i + 1 < length and sql[i + 1] == quote:
+                i += 2  # doubled quote → escaped, stay inside the span
+                continue
+            return i + 1
+        i += 1
+    return length
+
+
+def _scan_destructive_verb(sql: str) -> Optional[str]:
+    """Return the first destructive keyword that appears as a real SQL token.
+
+    Scans *sql* left-to-right, skipping string literals (``'...'``), quoted
+    identifiers (``"..."`` and MySQL ``` `...` ```), and comments (``-- ...``
+    and ``/* ... */``), and matches destructive verbs only as whole word
+    tokens. This catches destructive operations that are **not** the leading
+    keyword — which a first-token-only check misses — for example:
+
+    - data-modifying CTEs: ``WITH t AS (...) DELETE FROM users ...`` and
+      ``WITH t AS (DELETE FROM users ...) SELECT * FROM t``
+    - stacked statements: ``SELECT 1; DROP TABLE users``
+
+    while NOT misfiring on destructive words that appear inside string
+    literals, quoted identifiers, comments, or as substrings of an identifier
+    (e.g. ``'DELETE'``, ``"delete"``, ``deleted_at``).
+    """
+    length = len(sql)
+    i = 0
+    while i < length:
+        char = sql[i]
+        if char == "-" and i + 1 < length and sql[i + 1] == "-":
+            newline = sql.find("\n", i)
+            if newline == -1:
+                break
+            i = newline + 1
+        elif char == "/" and i + 1 < length and sql[i + 1] == "*":
+            end = sql.find("*/", i + 2)
+            if end == -1:
+                break
+            i = end + 2
+        elif char in ("'", '"', "`"):
+            i = _skip_quoted(sql, i, char)
+        elif char.isalpha() or char == "_":
+            start = i
+            i += 1
+            while i < length and (sql[i].isalnum() or sql[i] == "_"):
+                i += 1
+            if sql[start:i].upper() in DESTRUCTIVE_OPS:
+                return sql[start:i].upper()
+        else:
+            i += 1
+    return None
+
+
 def detect_destructive_operation(sql_query: str) -> tuple[str, bool]:
     """Return ``(sql_type, is_destructive)`` for a SQL statement.
 
-    Strips leading SQL comments before classifying so attackers cannot
-    bypass destructive-op confirmation by prefixing a comment.
+    Strips leading SQL comments before classifying so a comment prefix cannot
+    bypass destructive-op confirmation. Because a first-token-only check misses
+    data-modifying CTEs (``WITH t AS (...) DELETE FROM ...``) and stacked
+    statements (``SELECT 1; DROP TABLE ...``) — which would otherwise execute
+    without confirmation and bypass the demo-graph read-only guard — the whole
+    statement is then scanned (ignoring strings, quoted identifiers, and
+    comments) for any destructive verb. If one is found, the operation is
+    treated as destructive and the reported ``sql_type`` is that verb so the
+    confirmation message names the real mutation.
     """
     if not sql_query:
         return "", False
     cleaned = _strip_sql_comments_and_whitespace(sql_query)
-    sql_type = cleaned.split()[0].upper() if cleaned else ""
-    return sql_type, sql_type in DESTRUCTIVE_OPS
+    if not cleaned:
+        return "", False
+    first_token = cleaned.split()[0].upper()
+    if first_token in DESTRUCTIVE_OPS:
+        return first_token, True
+    hidden_verb = _scan_destructive_verb(cleaned)
+    if hidden_verb is not None:
+        return hidden_verb, True
+    return first_token, False
 
 
 def auto_quote_sql_identifiers(

--- a/api/core/pipeline.py
+++ b/api/core/pipeline.py
@@ -9,7 +9,10 @@ import asyncio
 import contextvars
 import logging
 import os
+import re
 from typing import Any, Optional, Type
+
+import sqlglot
 
 from api.agents import ResponseFormatterAgent
 from api.config import Config
@@ -31,9 +34,12 @@ MESSAGE_DELIMITER = "|||FALKORDB_MESSAGE_BOUNDARY|||"
 
 GENERAL_PREFIX = os.getenv("GENERAL_PREFIX")
 
-# Verb → user-facing description for destructive operations. Single source of
-# truth for both ``DESTRUCTIVE_OPS`` (membership test) and the confirmation
-# message builder, so adding a verb in one place can't drift from the other.
+# Verb → user-facing description for destructive operations. Used by the
+# confirmation-message builder and exposed as ``DESTRUCTIVE_OPS`` (the set of
+# named destructive verbs). Detection itself is AST-based (see
+# ``detect_destructive_operation``), so this map only needs the verbs we want a
+# friendly description for; any other mutation still triggers confirmation with
+# a generic description.
 _DESTRUCTIVE_VERBS = {
     'INSERT': 'Add new data to the database',
     'REPLACE': 'Replace data in the database (deletes conflicting rows, then inserts)',
@@ -43,6 +49,10 @@ _DESTRUCTIVE_VERBS = {
     'CREATE': 'Create new tables or database objects',
     'ALTER': 'Modify the structure of existing tables',
     'TRUNCATE': '**PERMANENTLY DELETE ALL DATA** from specified tables',
+    'MERGE': 'Insert, update, or delete rows in the database',
+    'GRANT': 'Change database access privileges',
+    'REVOKE': 'Change database access privileges',
+    'COPY': 'Bulk-load data into the database',
 }
 
 DESTRUCTIVE_OPS = frozenset(_DESTRUCTIVE_VERBS)
@@ -189,159 +199,135 @@ def truncate_for_log(query: str, max_length: int = 200) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _strip_sql_comments_and_whitespace(sql_query: str) -> str:
-    """Strip leading SQL comments (-- line and /* block */) and whitespace.
+# Internal db_type → sqlglot dialect. Unknown/None types parse dialect-agnostic.
+_DIALECT_BY_DB_TYPE = {
+    "postgresql": "postgres",
+    "postgres": "postgres",
+    "mysql": "mysql",
+    "snowflake": "snowflake",
+}
 
-    A naive ``strip().split()[0]`` lets ``-- evil\\nDROP TABLE x`` masquerade
-    as a non-destructive statement, bypassing confirmation.
+# sqlglot expression class names that represent a write, DDL, privilege change,
+# bulk load, or ``SELECT ... INTO``. Any of these anywhere in the parse tree
+# (including inside CTEs and subqueries) makes the whole statement destructive.
+_DESTRUCTIVE_EXP_NAMES = frozenset({
+    "Insert", "Update", "Delete", "Merge", "Drop", "Create", "Alter",
+    "AlterTable", "TruncateTable", "Truncate", "Copy", "Grant", "Revoke",
+    "Into",
+})
+
+# sqlglot expression class name → short verb for the confirmation message.
+_EXP_NAME_TO_VERB = {
+    "Insert": "INSERT", "Update": "UPDATE", "Delete": "DELETE", "Merge": "MERGE",
+    "Drop": "DROP", "Create": "CREATE", "Alter": "ALTER", "AlterTable": "ALTER",
+    "TruncateTable": "TRUNCATE", "Truncate": "TRUNCATE", "Copy": "COPY",
+    "Grant": "GRANT", "Revoke": "REVOKE", "Into": "SELECT ... INTO",
+}
+
+# Reported as ``sql_type`` when a statement cannot be parsed and is therefore
+# treated as destructive out of caution.
+_UNKNOWN_DESTRUCTIVE_TYPE = "UNKNOWN"
+
+# sqlglot logs a WARNING whenever it falls back to a generic Command for syntax
+# it does not model (e.g. REPLACE INTO, CALL). That fallback is expected and
+# handled by detect_destructive_operation, so quiet those warnings.
+logging.getLogger("sqlglot").setLevel(logging.ERROR)
+
+
+# Opening marker of a MySQL/MariaDB "executable comment" (``/*! ...``,
+# ``/*!50110 ...``, ``/*M! ...``): the server RUNS the payload, so we must not
+# let it be discarded as an ordinary comment before parsing.
+_EXECUTABLE_COMMENT_OPEN = re.compile(r"/\*(?:!|M!)\d*")
+
+
+def _unwrap_executable_comments(sql: str) -> str:
+    """Inline the payload of MySQL/MariaDB executable comments.
+
+    sqlglot treats ``/*! ... */`` as an ordinary comment and drops its
+    contents, but MySQL/MariaDB execute that payload. Rewriting the markers to
+    whitespace exposes the payload (e.g. ``/*! DROP TABLE users */`` →
+    `` DROP TABLE users ``) so the destructive statement is actually parsed.
     """
-    text = sql_query.lstrip()
-    while text:
-        if text.startswith("--"):
-            newline = text.find("\n")
-            if newline == -1:
-                return ""
-            text = text[newline + 1:].lstrip()
-        elif text.startswith("/*"):
-            # MySQL/MariaDB executable comments (/*! ... */, /*M! ... */) are run
-            # by the server, so they must NOT be stripped — leave them in place
-            # for the destructive-verb scanner to inspect.
-            if text.startswith("/*!") or text.startswith("/*M!"):
-                break
-            end = text.find("*/")
-            if end == -1:
-                return ""
-            text = text[end + 2:].lstrip()
-        else:
+    result = []
+    pos = 0
+    while True:
+        match = _EXECUTABLE_COMMENT_OPEN.search(sql, pos)
+        if match is None:
+            result.append(sql[pos:])
             break
-    return text
+        close = sql.find("*/", match.end())
+        if close == -1:
+            result.append(sql[pos:])
+            break
+        result.append(sql[pos:match.start()])
+        result.append(" ")
+        result.append(sql[match.end():close])
+        result.append(" ")
+        pos = close + 2
+    return "".join(result)
 
 
-def _skip_quoted(sql: str, start: int, quote: str) -> int:
-    """Return the index just past the quoted span that begins at *start*.
-
-    Handles the SQL doubled-quote escape (``''``, ``""``) so an escaped quote
-    does not prematurely end the span. An unterminated quote consumes the rest
-    of the string. Used to ignore string literals and quoted identifiers when
-    scanning for SQL keywords.
-    """
-    length = len(sql)
-    i = start + 1
-    while i < length:
-        if sql[i] == quote:
-            if i + 1 < length and sql[i + 1] == quote:
-                i += 2  # doubled quote → escaped, stay inside the span
-                continue
-            return i + 1
-        i += 1
-    return length
+def _sqlglot_dialect(db_type: Optional[str]) -> Optional[str]:
+    """Map an internal ``db_type`` to a sqlglot dialect name (or None)."""
+    if not db_type:
+        return None
+    return _DIALECT_BY_DB_TYPE.get(db_type.strip().lower())
 
 
-def _is_function_call(sql: str, index: int) -> bool:
-    """Whether the token ending at *index* is immediately followed by ``(``.
-
-    A destructive verb followed by ``(`` (ignoring whitespace) is a same-named
-    SQL function — e.g. MySQL ``INSERT()``/``REPLACE()`` string functions or
-    ``TRUNCATE()`` numeric function — which is read-only, not the statement
-    keyword ``REPLACE INTO`` / ``INSERT INTO`` / ``TRUNCATE TABLE``.
-    """
-    i = index
-    length = len(sql)
-    while i < length and sql[i] in " \t\r\n":
-        i += 1
-    return i < length and sql[i] == "("
-
-
-def _skip_non_code(sql: str, i: int) -> int:
-    """Return the index just past an ignorable span starting at *i*, else -1.
-
-    Ignorable spans are ordinary comments (``-- ...``, ``/* ... */``), string
-    literals (``'...'``), and quoted identifiers (``"..."``, ``` `...` ```).
-    A MySQL/MariaDB executable comment (``/*! ... */``, ``/*M! ... */``) runs on
-    the server, so only its marker is consumed and its payload is left to be
-    scanned. Returns -1 when *i* does not start an ignorable span.
-    """
-    length = len(sql)
-    char = sql[i]
-    if char == "-" and i + 1 < length and sql[i + 1] == "-":
-        newline = sql.find("\n", i)
-        return length if newline == -1 else newline + 1
-    if char == "/" and i + 1 < length and sql[i + 1] == "*":
-        if i + 2 < length and sql[i + 2] == "!":
-            return i + 3
-        if i + 3 < length and sql[i + 2] == "M" and sql[i + 3] == "!":
-            return i + 4
-        end = sql.find("*/", i + 2)
-        return length if end == -1 else end + 2
-    if char in ("'", '"', "`"):
-        return _skip_quoted(sql, i, char)
-    return -1
-
-
-def _scan_destructive_verb(sql: str) -> Optional[str]:
-    """Return the first destructive keyword that appears as a real SQL token.
-
-    Scans *sql* left-to-right, skipping string literals, quoted identifiers,
-    and ordinary comments (see :func:`_skip_non_code`), and matches destructive
-    verbs only as whole word tokens that are not function calls. This catches
-    destructive operations that are **not** the leading keyword — which a
-    first-token-only check misses — for example:
-
-    - data-modifying CTEs: ``WITH t AS (...) DELETE FROM users ...`` and
-      ``WITH t AS (DELETE FROM users ...) SELECT * FROM t``
-    - stacked statements: ``SELECT 1; DROP TABLE users``
-    - MySQL/MariaDB executable comments: ``/*! DROP TABLE users */``
-
-    while NOT misfiring on destructive words that appear inside string literals,
-    quoted identifiers, ordinary comments, as substrings of an identifier
-    (``deleted_at``), or as function calls (``REPLACE(...)``, ``INSERT(...)``).
-    """
-    length = len(sql)
-    i = 0
-    while i < length:
-        skipped = _skip_non_code(sql, i)
-        if skipped != -1:
-            i = skipped
-            continue
-        char = sql[i]
-        if char.isalpha() or char == "_":
-            start = i
-            i += 1
-            while i < length and (sql[i].isalnum() or sql[i] == "_"):
-                i += 1
-            word = sql[start:i].upper()
-            if word in DESTRUCTIVE_OPS and not _is_function_call(sql, i):
-                return word
-        else:
-            i += 1
-    return None
-
-
-def detect_destructive_operation(sql_query: str) -> tuple[str, bool]:
+def detect_destructive_operation(
+    sql_query: str, db_type: Optional[str] = None
+) -> tuple[str, bool]:
     """Return ``(sql_type, is_destructive)`` for a SQL statement.
 
-    Strips leading SQL comments before classifying so a comment prefix cannot
-    bypass destructive-op confirmation. Because a first-token-only check misses
-    data-modifying CTEs (``WITH t AS (...) DELETE FROM ...``) and stacked
-    statements (``SELECT 1; DROP TABLE ...``) — which would otherwise execute
-    without confirmation and bypass the demo-graph read-only guard — the whole
-    statement is then scanned (ignoring strings, quoted identifiers, and
-    comments) for any destructive verb. If one is found, the operation is
-    treated as destructive and the reported ``sql_type`` is that verb so the
-    confirmation message names the real mutation.
+    Parses *sql_query* with sqlglot (dialect-aware when *db_type* is given) and
+    inspects the full AST, so classification is not fooled by anything that
+    hides a write behind the first token:
+
+    - data-modifying CTEs — ``WITH t AS (...) DELETE FROM users ...`` and
+      ``WITH t AS (DELETE FROM users ...) SELECT * FROM t``
+    - stacked statements — ``SELECT 1; DROP TABLE users``
+    - MySQL/MariaDB executable comments — ``/*! DROP TABLE users */``
+    - dialect-specific string/comment escapes (backslash escapes, dollar
+      quoting, ``#`` comments) that a hand-rolled scanner mis-tokenises
+
+    Any write (INSERT/UPDATE/DELETE/MERGE/REPLACE), DDL (CREATE/DROP/ALTER/
+    TRUNCATE/RENAME), privilege change (GRANT/REVOKE), bulk load (COPY/LOAD),
+    ``SELECT ... INTO``, or generically-parsed command marks the statement
+    destructive so it cannot bypass the confirmation prompt or the demo-graph
+    read-only guard. The reported ``sql_type`` names the operation for the
+    confirmation message.
+
+    The check is conservative: a statement sqlglot cannot parse is treated as
+    destructive rather than executed unconfirmed.
     """
-    if not sql_query:
+    if not sql_query or not sql_query.strip():
         return "", False
-    cleaned = _strip_sql_comments_and_whitespace(sql_query)
-    if not cleaned:
+    prepared = _unwrap_executable_comments(sql_query)
+    try:
+        statements = [
+            stmt
+            for stmt in sqlglot.parse(prepared, read=_sqlglot_dialect(db_type))
+            if stmt is not None
+        ]
+    except Exception:  # pylint: disable=broad-exception-caught
+        # Unparseable → we cannot prove it is read-only → require confirmation.
+        return _UNKNOWN_DESTRUCTIVE_TYPE, True
+    if not statements:
         return "", False
-    first_token = cleaned.split()[0].upper()
-    if first_token in DESTRUCTIVE_OPS:
-        return first_token, True
-    hidden_verb = _scan_destructive_verb(cleaned)
-    if hidden_verb is not None:
-        return hidden_verb, True
-    return first_token, False
+    for statement in statements:
+        for node in statement.walk():
+            node = node[0] if isinstance(node, tuple) else node
+            name = type(node).__name__
+            if name in _DESTRUCTIVE_EXP_NAMES:
+                return _EXP_NAME_TO_VERB.get(name, name.upper()), True
+            # A statement sqlglot cannot model structurally falls back to a
+            # generic Command (REPLACE INTO, CALL, RENAME, DO, LOAD, VACUUM,
+            # EXPLAIN ANALYZE ...). We cannot prove these are read-only, so treat
+            # them as destructive, named by their leading keyword.
+            if name == "Command":
+                keyword = str(node.this).strip().upper() if node.this else ""
+                return keyword or "COMMAND", True
+    return type(statements[0]).__name__.upper(), False
 
 
 def auto_quote_sql_identifiers(

--- a/api/core/pipeline.py
+++ b/api/core/pipeline.py
@@ -228,11 +228,6 @@ _EXP_NAME_TO_VERB = {
 # treated as destructive out of caution.
 _UNKNOWN_DESTRUCTIVE_TYPE = "UNKNOWN"
 
-# sqlglot logs a WARNING whenever it falls back to a generic Command for syntax
-# it does not model (e.g. REPLACE INTO, CALL). That fallback is expected and
-# handled by detect_destructive_operation, so quiet those warnings.
-logging.getLogger("sqlglot").setLevel(logging.ERROR)
-
 
 # Opening marker of a MySQL/MariaDB "executable comment" (``/*! ...``,
 # ``/*!50110 ...``, ``/*M! ...``): the server RUNS the payload, so we must not
@@ -275,7 +270,7 @@ def _sqlglot_dialect(db_type: Optional[str]) -> Optional[str]:
 
 
 def detect_destructive_operation(
-    sql_query: str, db_type: Optional[str] = None
+    sql_query: Optional[str], db_type: Optional[str] = None
 ) -> tuple[str, bool]:
     """Return ``(sql_type, is_destructive)`` for a SQL statement.
 
@@ -303,6 +298,13 @@ def detect_destructive_operation(
     if not sql_query or not sql_query.strip():
         return "", False
     prepared = _unwrap_executable_comments(sql_query)
+    # sqlglot logs a WARNING when it falls back to a generic Command for syntax
+    # it does not model (e.g. REPLACE INTO, CALL). That fallback is expected and
+    # handled below, so quiet those warnings only for the duration of our parse
+    # instead of mutating the "sqlglot" logger globally at import time.
+    sqlglot_logger = logging.getLogger("sqlglot")
+    previous_level = sqlglot_logger.level
+    sqlglot_logger.setLevel(logging.ERROR)
     try:
         statements = [
             stmt
@@ -312,6 +314,8 @@ def detect_destructive_operation(
     except Exception:  # pylint: disable=broad-exception-caught
         # Unparseable → we cannot prove it is read-only → require confirmation.
         return _UNKNOWN_DESTRUCTIVE_TYPE, True
+    finally:
+        sqlglot_logger.setLevel(previous_level)
     if not statements:
         return "", False
     for statement in statements:

--- a/api/core/pipeline.py
+++ b/api/core/pipeline.py
@@ -36,6 +36,7 @@ GENERAL_PREFIX = os.getenv("GENERAL_PREFIX")
 # message builder, so adding a verb in one place can't drift from the other.
 _DESTRUCTIVE_VERBS = {
     'INSERT': 'Add new data to the database',
+    'REPLACE': 'Replace data in the database (deletes conflicting rows, then inserts)',
     'UPDATE': 'Modify existing data in the database',
     'DELETE': '**PERMANENTLY DELETE** data from the database',
     'DROP': '**PERMANENTLY DELETE** entire tables or database objects',
@@ -202,6 +203,11 @@ def _strip_sql_comments_and_whitespace(sql_query: str) -> str:
                 return ""
             text = text[newline + 1:].lstrip()
         elif text.startswith("/*"):
+            # MySQL/MariaDB executable comments (/*! ... */, /*M! ... */) are run
+            # by the server, so they must NOT be stripped — leave them in place
+            # for the destructive-verb scanner to inspect.
+            if text.startswith("/*!") or text.startswith("/*M!"):
+                break
             end = text.find("*/")
             if end == -1:
                 return ""
@@ -231,46 +237,81 @@ def _skip_quoted(sql: str, start: int, quote: str) -> int:
     return length
 
 
+def _is_function_call(sql: str, index: int) -> bool:
+    """Whether the token ending at *index* is immediately followed by ``(``.
+
+    A destructive verb followed by ``(`` (ignoring whitespace) is a same-named
+    SQL function — e.g. MySQL ``INSERT()``/``REPLACE()`` string functions or
+    ``TRUNCATE()`` numeric function — which is read-only, not the statement
+    keyword ``REPLACE INTO`` / ``INSERT INTO`` / ``TRUNCATE TABLE``.
+    """
+    i = index
+    length = len(sql)
+    while i < length and sql[i] in " \t\r\n":
+        i += 1
+    return i < length and sql[i] == "("
+
+
+def _skip_non_code(sql: str, i: int) -> int:
+    """Return the index just past an ignorable span starting at *i*, else -1.
+
+    Ignorable spans are ordinary comments (``-- ...``, ``/* ... */``), string
+    literals (``'...'``), and quoted identifiers (``"..."``, ``` `...` ```).
+    A MySQL/MariaDB executable comment (``/*! ... */``, ``/*M! ... */``) runs on
+    the server, so only its marker is consumed and its payload is left to be
+    scanned. Returns -1 when *i* does not start an ignorable span.
+    """
+    length = len(sql)
+    char = sql[i]
+    if char == "-" and i + 1 < length and sql[i + 1] == "-":
+        newline = sql.find("\n", i)
+        return length if newline == -1 else newline + 1
+    if char == "/" and i + 1 < length and sql[i + 1] == "*":
+        if i + 2 < length and sql[i + 2] == "!":
+            return i + 3
+        if i + 3 < length and sql[i + 2] == "M" and sql[i + 3] == "!":
+            return i + 4
+        end = sql.find("*/", i + 2)
+        return length if end == -1 else end + 2
+    if char in ("'", '"', "`"):
+        return _skip_quoted(sql, i, char)
+    return -1
+
+
 def _scan_destructive_verb(sql: str) -> Optional[str]:
     """Return the first destructive keyword that appears as a real SQL token.
 
-    Scans *sql* left-to-right, skipping string literals (``'...'``), quoted
-    identifiers (``"..."`` and MySQL ``` `...` ```), and comments (``-- ...``
-    and ``/* ... */``), and matches destructive verbs only as whole word
-    tokens. This catches destructive operations that are **not** the leading
-    keyword — which a first-token-only check misses — for example:
+    Scans *sql* left-to-right, skipping string literals, quoted identifiers,
+    and ordinary comments (see :func:`_skip_non_code`), and matches destructive
+    verbs only as whole word tokens that are not function calls. This catches
+    destructive operations that are **not** the leading keyword — which a
+    first-token-only check misses — for example:
 
     - data-modifying CTEs: ``WITH t AS (...) DELETE FROM users ...`` and
       ``WITH t AS (DELETE FROM users ...) SELECT * FROM t``
     - stacked statements: ``SELECT 1; DROP TABLE users``
+    - MySQL/MariaDB executable comments: ``/*! DROP TABLE users */``
 
-    while NOT misfiring on destructive words that appear inside string
-    literals, quoted identifiers, comments, or as substrings of an identifier
-    (e.g. ``'DELETE'``, ``"delete"``, ``deleted_at``).
+    while NOT misfiring on destructive words that appear inside string literals,
+    quoted identifiers, ordinary comments, as substrings of an identifier
+    (``deleted_at``), or as function calls (``REPLACE(...)``, ``INSERT(...)``).
     """
     length = len(sql)
     i = 0
     while i < length:
+        skipped = _skip_non_code(sql, i)
+        if skipped != -1:
+            i = skipped
+            continue
         char = sql[i]
-        if char == "-" and i + 1 < length and sql[i + 1] == "-":
-            newline = sql.find("\n", i)
-            if newline == -1:
-                break
-            i = newline + 1
-        elif char == "/" and i + 1 < length and sql[i + 1] == "*":
-            end = sql.find("*/", i + 2)
-            if end == -1:
-                break
-            i = end + 2
-        elif char in ("'", '"', "`"):
-            i = _skip_quoted(sql, i, char)
-        elif char.isalpha() or char == "_":
+        if char.isalpha() or char == "_":
             start = i
             i += 1
             while i < length and (sql[i].isalnum() or sql[i] == "_"):
                 i += 1
-            if sql[start:i].upper() in DESTRUCTIVE_OPS:
-                return sql[start:i].upper()
+            word = sql[start:i].upper()
+            if word in DESTRUCTIVE_OPS and not _is_function_call(sql, i):
+                return word
         else:
             i += 1
     return None

--- a/api/core/text2sql.py
+++ b/api/core/text2sql.py
@@ -523,6 +523,17 @@ async def run_query(  # pylint: disable=too-many-locals,too-many-branches,too-ma
             healer = HealerAgent(max_healing_attempts=3)
 
             def _run_sql(sql: str):
+                # Defense in depth: the healer LLM must never turn a
+                # non-destructive query into a write that skips the
+                # confirmation / demo-graph guard. Reject destructive healed
+                # SQL rather than execute it silently.
+                healed_type, healed_destructive = detect_destructive_operation(sql)
+                if healed_destructive:
+                    raise InvalidArgumentError(
+                        "Healed SQL rejected: it performs a destructive "
+                        f"{healed_type} operation, which requires explicit "
+                        "user confirmation and cannot run during auto-healing."
+                    )
                 return loader_class.execute_sql_query(sql, db_url)
 
             healing_result = healer.heal_and_execute(

--- a/api/core/text2sql.py
+++ b/api/core/text2sql.py
@@ -463,7 +463,7 @@ async def run_query(  # pylint: disable=too-many-locals,too-many-branches,too-ma
         answer_an["sql_query"] = sanitized_sql
 
     sql_query = answer_an["sql_query"]
-    sql_type, is_destructive = detect_destructive_operation(sql_query)
+    sql_type, is_destructive = detect_destructive_operation(sql_query, db_type)
     on_demo = is_general_graph(namespaced)
 
     if is_destructive and on_demo:
@@ -527,7 +527,7 @@ async def run_query(  # pylint: disable=too-many-locals,too-many-branches,too-ma
                 # non-destructive query into a write that skips the
                 # confirmation / demo-graph guard. Reject destructive healed
                 # SQL rather than execute it silently.
-                healed_type, healed_destructive = detect_destructive_operation(sql)
+                healed_type, healed_destructive = detect_destructive_operation(sql, db_type)
                 if healed_destructive:
                     raise InvalidArgumentError(
                         "Healed SQL rejected: it performs a destructive "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "tqdm>=4.67.3,<4.69.0",
     "pydantic>=2.0",
     "python-dotenv~=1.2.2",
+    "sqlglot>=30.12.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_destructive_detection.py
+++ b/tests/test_destructive_detection.py
@@ -216,6 +216,35 @@ class TestConservativeFallback:
         # and EXPLAIN ANALYZE <write> executes, so treat it as destructive.
         assert detect_destructive_operation("EXPLAIN ANALYZE DELETE FROM users", "postgresql")[1] is True
 
+    def test_unclosed_executable_comment_is_destructive(self):
+        # A dangling /*! with no closing */ cannot be proven read-only.
+        assert detect_destructive_operation("SELECT 1 /*! DROP TABLE users", "mysql")[1] is True
+
+    def test_execute_immediate_is_destructive(self):
+        assert detect_destructive_operation("EXECUTE IMMEDIATE 'DROP TABLE users'", "snowflake")[1] is True
+
+    def test_comment_on_is_destructive(self):
+        assert detect_destructive_operation("COMMENT ON TABLE users IS 'obsolete'", "postgresql")[1] is True
+
+
+class TestNestedQuoteEdgeCases:
+    """Escape/quote constructs that must not create a false positive or a
+    false negative once executable comments are unwrapped and sqlglot parses."""
+
+    def test_marker_inside_string_literal_is_read_only(self):
+        # An executable-comment marker that is really inside a string literal
+        # must not turn a plain read into a (false) destructive result.
+        sql = "SELECT '/*! DROP TABLE users */' AS s FROM t"
+        assert detect_destructive_operation(sql, "mysql")[1] is False
+
+    def test_dollar_quoted_select_literal_is_read_only(self):
+        sql = "SELECT $$Please DELETE this text$$ AS message"
+        assert detect_destructive_operation(sql, "postgresql")[1] is False
+
+    def test_tagged_dollar_quote_hiding_write_is_destructive(self):
+        sql = "WITH cte AS (SELECT $tag$'$tag$ AS s) DELETE FROM users WHERE id = 1"
+        assert detect_destructive_operation(sql, "postgresql") == ("DELETE", True)
+
 
 class TestEdgeCases:
     """Empty / degenerate inputs."""

--- a/tests/test_destructive_detection.py
+++ b/tests/test_destructive_detection.py
@@ -160,25 +160,34 @@ class TestDialectEscapeBypasses:
 
 
 class TestExecutableComments:
-    """MySQL/MariaDB executable comments run on the server, so a destructive
-    payload inside one must be detected — not dropped like a normal comment."""
+    """MySQL/MariaDB executable comments run their payload on the server, but
+    sqlglot drops them as ordinary comments. Since a comment/string-blind
+    rewrite can be bypassed, MySQL detection fails safe on the marker: any
+    executable-comment marker makes the statement conservatively destructive."""
 
     def test_executable_comment_drop(self):
-        assert detect_destructive_operation("/*! DROP TABLE users */", "mysql") == ("DROP", True)
+        assert detect_destructive_operation("/*! DROP TABLE users */", "mysql")[1] is True
 
     def test_version_gated_executable_comment(self):
-        assert detect_destructive_operation("/*!50110 DROP TABLE users */", "mysql") == ("DROP", True)
+        assert detect_destructive_operation("/*!50110 DROP TABLE users */", "mysql")[1] is True
 
     def test_mariadb_executable_comment(self):
-        assert detect_destructive_operation("/*M! DELETE FROM users */", "mysql") == ("DELETE", True)
+        assert detect_destructive_operation("/*M! DELETE FROM users */", "mysql")[1] is True
 
     def test_executable_comment_fragment_inside_read(self):
         sql = "SELECT * FROM t WHERE 1 /*! ; DELETE FROM t */"
         assert detect_destructive_operation(sql, "mysql")[1] is True
 
-    def test_benign_executable_comment_is_read_only(self):
+    def test_executable_comment_marker_is_conservatively_destructive(self):
+        # Even a benign-looking executable comment is flagged (fail safe), since
+        # its payload cannot be reliably distinguished from a destructive one.
         sql = "/*!40101 SET NAMES utf8 */; SELECT * FROM users"
-        assert detect_destructive_operation(sql, "mysql")[1] is False
+        assert detect_destructive_operation(sql, "mysql")[1] is True
+
+    def test_executable_comment_ignored_for_non_mysql_dialect(self):
+        # For PostgreSQL, /*! ... */ is a plain (non-executable) comment, so a
+        # benign read is not flagged.
+        assert detect_destructive_operation("SELECT 1 /*! comment */ FROM t", "postgresql")[1] is False
 
     def test_ordinary_block_comment_is_ignored(self):
         assert detect_destructive_operation("SELECT 1 /* DROP TABLE users */")[1] is False
@@ -227,15 +236,35 @@ class TestConservativeFallback:
         assert detect_destructive_operation("COMMENT ON TABLE users IS 'obsolete'", "postgresql")[1] is True
 
 
+class TestFailClosedRoots:
+    """Statements sqlglot parses to an unexpected/non read-only root must be
+    treated as destructive (fail closed), not slipped through as read-only."""
+
+    @pytest.mark.parametrize(
+        "sql,dialect",
+        [
+            ("RESET MASTER", "mysql"),          # deletes binary logs
+            ("SHUTDOWN", "mysql"),
+            ("UNDROP TABLE users", "snowflake"),  # catalog write
+            ("CLUSTER users", "postgresql"),      # rewrites the table
+            ("SET GLOBAL read_only = OFF", "mysql"),
+            ("SET PERSIST max_connections = 200", "mysql"),
+            ("USE otherdb", "mysql"),
+        ],
+    )
+    def test_non_readonly_root_is_destructive(self, sql, dialect):
+        assert detect_destructive_operation(sql, dialect)[1] is True
+
+
 class TestNestedQuoteEdgeCases:
     """Escape/quote constructs that must not create a false positive or a
     false negative once executable comments are unwrapped and sqlglot parses."""
 
-    def test_marker_inside_string_literal_is_read_only(self):
-        # An executable-comment marker that is really inside a string literal
-        # must not turn a plain read into a (false) destructive result.
+    def test_marker_inside_string_literal_is_conservatively_destructive(self):
+        # A /*! marker inside a string literal is a rare, safe false positive:
+        # for MySQL the fail-safe flags any marker rather than risk a bypass.
         sql = "SELECT '/*! DROP TABLE users */' AS s FROM t"
-        assert detect_destructive_operation(sql, "mysql")[1] is False
+        assert detect_destructive_operation(sql, "mysql")[1] is True
 
     def test_dollar_quoted_select_literal_is_read_only(self):
         sql = "SELECT $$Please DELETE this text$$ AS message"

--- a/tests/test_destructive_detection.py
+++ b/tests/test_destructive_detection.py
@@ -1,0 +1,188 @@
+"""Unit tests for destructive-operation detection in ``api.core.pipeline``.
+
+These tests focus on the confirmation/demo-graph safety gate: a statement that
+mutates data or schema MUST be classified as destructive so it cannot execute
+without user confirmation. They cover a previously exploitable bypass where a
+first-token-only check missed data-modifying CTEs (``WITH ... DELETE ...``) and
+stacked statements (``SELECT 1; DROP TABLE ...``), while making sure ordinary
+read-only queries are not misclassified.
+"""
+
+import pytest
+
+from api.core.pipeline import (
+    DESTRUCTIVE_OPS,
+    build_destructive_confirmation_message,
+    detect_destructive_operation,
+)
+
+
+class TestPlainDestructiveOperations:
+    """A statement that starts with a destructive verb is destructive."""
+
+    @pytest.mark.parametrize("verb", sorted(DESTRUCTIVE_OPS))
+    def test_leading_verb_is_destructive(self, verb):
+        sql = f"{verb} something here"
+        sql_type, is_destructive = detect_destructive_operation(sql)
+        assert is_destructive is True
+        assert sql_type == verb
+
+    def test_leading_verb_is_case_insensitive(self):
+        assert detect_destructive_operation("delete from users") == ("DELETE", True)
+        assert detect_destructive_operation("InSeRt into t values (1)") == ("INSERT", True)
+
+    def test_leading_whitespace_and_newlines(self):
+        assert detect_destructive_operation("\n\t  DELETE FROM users") == ("DELETE", True)
+
+
+class TestReadOnlyOperations:
+    """Read-only statements must never be flagged as destructive."""
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "SELECT * FROM users",
+            "select id, name from users where id = 1",
+            "WITH t AS (SELECT id FROM orders) SELECT * FROM t",
+            "WITH RECURSIVE t AS (SELECT 1) SELECT * FROM t",
+            "EXPLAIN SELECT * FROM users",
+            "SELECT * FROM users WHERE status = 'active'",
+        ],
+    )
+    def test_select_is_not_destructive(self, sql):
+        sql_type, is_destructive = detect_destructive_operation(sql)
+        assert is_destructive is False
+        assert sql_type == sql.strip().split()[0].upper()
+
+
+class TestDataModifyingCteBypass:
+    """Regression tests for the CTE / stacked-statement confirmation bypass.
+
+    A data-modifying CTE reads as ``WITH`` on its first token, so a
+    first-token-only classifier treated it as read-only and executed the write
+    without confirmation (and bypassed the demo-graph guard). These must all be
+    detected as destructive.
+    """
+
+    def test_write_after_cte_is_destructive(self):
+        # The write is at the top level, after the CTE definition.
+        sql = (
+            "WITH doomed AS (SELECT id FROM users WHERE inactive) "
+            "DELETE FROM users WHERE id IN (SELECT id FROM doomed)"
+        )
+        assert detect_destructive_operation(sql) == ("DELETE", True)
+
+    def test_write_inside_cte_body_is_destructive(self):
+        # PostgreSQL data-modifying CTE: the write lives inside the CTE body.
+        sql = (
+            "WITH removed AS (DELETE FROM users WHERE id = 5 RETURNING id) "
+            "SELECT * FROM removed"
+        )
+        assert detect_destructive_operation(sql) == ("DELETE", True)
+
+    def test_insert_via_cte_is_destructive(self):
+        sql = (
+            "WITH src AS (SELECT 1 AS id) "
+            "INSERT INTO audit (id) SELECT id FROM src"
+        )
+        assert detect_destructive_operation(sql) == ("INSERT", True)
+
+    def test_update_via_cte_is_destructive(self):
+        sql = (
+            "WITH t AS (SELECT id FROM users) "
+            "UPDATE users SET active = false WHERE id IN (SELECT id FROM t)"
+        )
+        assert detect_destructive_operation(sql) == ("UPDATE", True)
+
+    def test_cte_bypass_is_case_insensitive(self):
+        sql = "with t as (select 1) delete from users where id = 1"
+        assert detect_destructive_operation(sql) == ("DELETE", True)
+
+    def test_stacked_statement_is_destructive(self):
+        sql = "SELECT 1; DROP TABLE users"
+        assert detect_destructive_operation(sql) == ("DROP", True)
+
+    def test_leading_comment_then_cte_write_is_destructive(self):
+        sql = "/* harmless */ WITH t AS (SELECT 1) DELETE FROM users WHERE id = 1"
+        assert detect_destructive_operation(sql) == ("DELETE", True)
+
+
+class TestCommentBypass:
+    """Comment prefixes/inlines must not smuggle or fake destructive verbs."""
+
+    def test_line_comment_prefix_does_not_hide_delete(self):
+        sql = "-- just a comment\nDELETE FROM users"
+        assert detect_destructive_operation(sql) == ("DELETE", True)
+
+    def test_block_comment_prefix_does_not_hide_drop(self):
+        sql = "/* note */ DROP TABLE users"
+        assert detect_destructive_operation(sql) == ("DROP", True)
+
+    def test_destructive_word_only_in_line_comment_is_read_only(self):
+        sql = "SELECT id FROM users -- DELETE everything\n"
+        assert detect_destructive_operation(sql) == ("SELECT", False)
+
+    def test_destructive_word_only_in_block_comment_is_read_only(self):
+        sql = "SELECT id FROM users /* TODO: DROP later */ WHERE id = 1"
+        assert detect_destructive_operation(sql) == ("SELECT", False)
+
+
+class TestFalsePositiveGuards:
+    """Destructive words inside strings/identifiers must not trigger detection."""
+
+    def test_destructive_word_in_string_literal(self):
+        sql = "SELECT * FROM audit WHERE action = 'DELETE'"
+        assert detect_destructive_operation(sql) == ("SELECT", False)
+
+    def test_multiple_dml_words_in_string_literal(self):
+        sql = "SELECT * FROM audit WHERE action IN ('INSERT', 'UPDATE', 'DELETE')"
+        assert detect_destructive_operation(sql) == ("SELECT", False)
+
+    def test_escaped_quote_in_string_literal(self):
+        sql = "SELECT * FROM t WHERE note = 'it''s fine to DROP nothing'"
+        assert detect_destructive_operation(sql) == ("SELECT", False)
+
+    def test_destructive_word_in_double_quoted_identifier(self):
+        sql = 'SELECT "delete" FROM t'
+        assert detect_destructive_operation(sql) == ("SELECT", False)
+
+    def test_destructive_word_in_backtick_identifier(self):
+        sql = "SELECT `delete` FROM t"
+        assert detect_destructive_operation(sql) == ("SELECT", False)
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "SELECT deleted_at FROM users",
+            "SELECT update_count FROM stats",
+            "SELECT insert_ts, is_deleted FROM events",
+            "SELECT createdby FROM records",
+        ],
+    )
+    def test_destructive_word_as_identifier_substring(self, sql):
+        sql_type, is_destructive = detect_destructive_operation(sql)
+        assert is_destructive is False
+        assert sql_type == "SELECT"
+
+
+class TestEdgeCases:
+    """Empty / degenerate inputs."""
+
+    @pytest.mark.parametrize("sql", ["", "   ", "\n\t", None])
+    def test_empty_or_none_is_not_destructive(self, sql):
+        assert detect_destructive_operation(sql) == ("", False)
+
+    def test_only_comment_is_not_destructive(self):
+        assert detect_destructive_operation("-- nothing here") == ("", False)
+
+
+class TestConfirmationMessageIntegration:
+    """The confirmation message names the real mutation, even for CTEs."""
+
+    def test_cte_write_confirmation_names_delete(self):
+        sql = "WITH t AS (SELECT 1) DELETE FROM users WHERE id = 1"
+        sql_type, is_destructive = detect_destructive_operation(sql)
+        assert is_destructive is True
+        message = build_destructive_confirmation_message(sql_type, sql)
+        assert "DELETE" in message
+        assert "DESTRUCTIVE OPERATION DETECTED" in message

--- a/tests/test_destructive_detection.py
+++ b/tests/test_destructive_detection.py
@@ -1,11 +1,11 @@
 """Unit tests for destructive-operation detection in ``api.core.pipeline``.
 
-These tests focus on the confirmation/demo-graph safety gate: a statement that
-mutates data or schema MUST be classified as destructive so it cannot execute
-without user confirmation. They cover a previously exploitable bypass where a
-first-token-only check missed data-modifying CTEs (``WITH ... DELETE ...``) and
-stacked statements (``SELECT 1; DROP TABLE ...``), while making sure ordinary
-read-only queries are not misclassified.
+Detection is AST-based (sqlglot, dialect-aware). These tests focus on the
+confirmation / demo-graph safety gate: any statement that mutates data or
+schema — even when hidden in a CTE, a stacked statement, an executable comment,
+or behind dialect-specific escapes — must be classified destructive, while
+ordinary reads must not be. They also cover a previously exploitable bypass
+where a first-token-only check missed data-modifying CTEs and stacked writes.
 """
 
 import pytest
@@ -19,25 +19,32 @@ from api.core.pipeline import (
 pytestmark = pytest.mark.unit
 
 
-class TestPlainDestructiveOperations:
-    """A statement that starts with a destructive verb is destructive."""
+class TestPlainStatements:
+    """A statement whose operation is a write/DDL is destructive."""
 
-    @pytest.mark.parametrize("verb", sorted(DESTRUCTIVE_OPS))
-    def test_leading_verb_is_destructive(self, verb):
-        sql = f"{verb} something here"
-        sql_type, is_destructive = detect_destructive_operation(sql)
-        assert is_destructive is True
-        assert sql_type == verb
+    @pytest.mark.parametrize(
+        "sql,verb",
+        [
+            ("INSERT INTO users (id) VALUES (1)", "INSERT"),
+            ("UPDATE users SET active = FALSE WHERE id = 1", "UPDATE"),
+            ("DELETE FROM users WHERE id = 1", "DELETE"),
+            ("DROP TABLE users", "DROP"),
+            ("CREATE TABLE t (id INT)", "CREATE"),
+            ("ALTER TABLE users ADD COLUMN c INT", "ALTER"),
+            ("TRUNCATE TABLE users", "TRUNCATE"),
+        ],
+    )
+    def test_plain_write_is_destructive(self, sql, verb):
+        assert detect_destructive_operation(sql) == (verb, True)
 
-    def test_leading_verb_is_case_insensitive(self):
-        assert detect_destructive_operation("delete from users") == ("DELETE", True)
-        assert detect_destructive_operation("InSeRt into t values (1)") == ("INSERT", True)
+    def test_case_insensitive(self):
+        assert detect_destructive_operation("delete from users where id = 1") == ("DELETE", True)
 
-    def test_leading_whitespace_and_newlines(self):
+    def test_whitespace_prefixed(self):
         assert detect_destructive_operation("\n\t  DELETE FROM users") == ("DELETE", True)
 
 
-class TestReadOnlyOperations:
+class TestReadOnly:
     """Read-only statements must never be flagged as destructive."""
 
     @pytest.mark.parametrize(
@@ -47,14 +54,12 @@ class TestReadOnlyOperations:
             "select id, name from users where id = 1",
             "WITH t AS (SELECT id FROM orders) SELECT * FROM t",
             "WITH RECURSIVE t AS (SELECT 1) SELECT * FROM t",
-            "EXPLAIN SELECT * FROM users",
             "SELECT * FROM users WHERE status = 'active'",
+            "SELECT COUNT(*) FROM users",
         ],
     )
-    def test_select_is_not_destructive(self, sql):
-        sql_type, is_destructive = detect_destructive_operation(sql)
-        assert is_destructive is False
-        assert sql_type == sql.strip().split()[0].upper()
+    def test_reads_are_not_destructive(self, sql):
+        assert detect_destructive_operation(sql)[1] is False
 
 
 class TestDataModifyingCteBypass:
@@ -62,120 +67,171 @@ class TestDataModifyingCteBypass:
 
     A data-modifying CTE reads as ``WITH`` on its first token, so a
     first-token-only classifier treated it as read-only and executed the write
-    without confirmation (and bypassed the demo-graph guard). These must all be
-    detected as destructive.
+    without confirmation (and bypassed the demo-graph guard).
     """
 
-    def test_write_after_cte_is_destructive(self):
-        # The write is at the top level, after the CTE definition.
+    def test_write_after_cte(self):
         sql = (
-            "WITH doomed AS (SELECT id FROM users WHERE inactive) "
+            "WITH doomed AS (SELECT id FROM users) "
             "DELETE FROM users WHERE id IN (SELECT id FROM doomed)"
         )
         assert detect_destructive_operation(sql) == ("DELETE", True)
 
-    def test_write_inside_cte_body_is_destructive(self):
-        # PostgreSQL data-modifying CTE: the write lives inside the CTE body.
+    def test_write_inside_cte_body(self):
         sql = (
             "WITH removed AS (DELETE FROM users WHERE id = 5 RETURNING id) "
             "SELECT * FROM removed"
         )
-        assert detect_destructive_operation(sql) == ("DELETE", True)
+        assert detect_destructive_operation(sql, "postgresql") == ("DELETE", True)
 
-    def test_insert_via_cte_is_destructive(self):
-        sql = (
-            "WITH src AS (SELECT 1 AS id) "
-            "INSERT INTO audit (id) SELECT id FROM src"
-        )
+    def test_insert_via_cte(self):
+        sql = "WITH src AS (SELECT 1 AS id) INSERT INTO audit (id) SELECT id FROM src"
         assert detect_destructive_operation(sql) == ("INSERT", True)
 
-    def test_update_via_cte_is_destructive(self):
+    def test_update_via_cte(self):
         sql = (
             "WITH t AS (SELECT id FROM users) "
-            "UPDATE users SET active = false WHERE id IN (SELECT id FROM t)"
+            "UPDATE users SET active = FALSE WHERE id IN (SELECT id FROM t)"
         )
         assert detect_destructive_operation(sql) == ("UPDATE", True)
 
-    def test_cte_bypass_is_case_insensitive(self):
+    def test_case_insensitive_cte(self):
         sql = "with t as (select 1) delete from users where id = 1"
         assert detect_destructive_operation(sql) == ("DELETE", True)
 
-    def test_stacked_statement_is_destructive(self):
-        sql = "SELECT 1; DROP TABLE users"
-        assert detect_destructive_operation(sql) == ("DROP", True)
-
-    def test_leading_comment_then_cte_write_is_destructive(self):
-        sql = "/* harmless */ WITH t AS (SELECT 1) DELETE FROM users WHERE id = 1"
-        assert detect_destructive_operation(sql) == ("DELETE", True)
+    def test_stacked_statement(self):
+        assert detect_destructive_operation("SELECT 1; DROP TABLE users") == ("DROP", True)
 
 
-class TestCommentBypass:
-    """Comment prefixes/inlines must not smuggle or fake destructive verbs."""
+class TestExtraMutators:
+    """Writes/DDL/privilege/bulk ops beyond the basic verbs, caught via AST."""
 
-    def test_line_comment_prefix_does_not_hide_delete(self):
-        sql = "-- just a comment\nDELETE FROM users"
-        assert detect_destructive_operation(sql) == ("DELETE", True)
+    def test_merge(self):
+        sql = "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET t.v = s.v"
+        assert detect_destructive_operation(sql) == ("MERGE", True)
 
-    def test_block_comment_prefix_does_not_hide_drop(self):
-        sql = "/* note */ DROP TABLE users"
-        assert detect_destructive_operation(sql) == ("DROP", True)
+    def test_replace_into(self):
+        assert detect_destructive_operation("REPLACE INTO users VALUES (1, 'a')", "mysql") == (
+            "REPLACE",
+            True,
+        )
 
-    def test_destructive_word_only_in_line_comment_is_read_only(self):
-        sql = "SELECT id FROM users -- DELETE everything\n"
-        assert detect_destructive_operation(sql) == ("SELECT", False)
+    def test_replace_into_stacked(self):
+        assert detect_destructive_operation("SELECT 1; REPLACE INTO t VALUES (1)", "mysql")[1] is True
 
-    def test_destructive_word_only_in_block_comment_is_read_only(self):
-        sql = "SELECT id FROM users /* TODO: DROP later */ WHERE id = 1"
-        assert detect_destructive_operation(sql) == ("SELECT", False)
+    def test_select_into(self):
+        assert detect_destructive_operation("SELECT * INTO archived FROM users")[1] is True
+
+    def test_grant(self):
+        assert detect_destructive_operation("GRANT ALL ON users TO app")[1] is True
+
+    def test_revoke(self):
+        assert detect_destructive_operation("REVOKE SELECT ON users FROM app")[1] is True
+
+    def test_call_procedure(self):
+        assert detect_destructive_operation("CALL purge_users()")[1] is True
+
+    def test_rename_table(self):
+        assert detect_destructive_operation("RENAME TABLE users TO users_old", "mysql")[1] is True
+
+    def test_copy(self):
+        assert detect_destructive_operation("COPY users FROM '/data/u.csv'", "postgresql")[1] is True
+
+    def test_load_data(self):
+        sql = "LOAD DATA INFILE '/data/u.csv' INTO TABLE users"
+        assert detect_destructive_operation(sql, "mysql")[1] is True
+
+
+class TestDialectEscapeBypasses:
+    """Escapes/quotes/comments that a naive scanner mis-tokenises. sqlglot
+    parses them dialect-aware, so the hidden write is still detected."""
+
+    def test_postgres_dollar_quote_hiding_quote(self):
+        sql = "WITH cte AS (SELECT $$'$$ AS s) DELETE FROM users WHERE id = 1"
+        assert detect_destructive_operation(sql, "postgresql") == ("DELETE", True)
+
+    def test_mysql_backslash_escape(self):
+        sql = r"WITH cte AS (SELECT '\'' AS s) DELETE FROM users WHERE id = 1"
+        assert detect_destructive_operation(sql, "mysql") == ("DELETE", True)
+
+    def test_mysql_hash_comment(self):
+        sql = "WITH cte AS (SELECT 1 # x\n) DELETE FROM users WHERE id = 1"
+        assert detect_destructive_operation(sql, "mysql") == ("DELETE", True)
+
+
+class TestExecutableComments:
+    """MySQL/MariaDB executable comments run on the server, so a destructive
+    payload inside one must be detected — not dropped like a normal comment."""
+
+    def test_executable_comment_drop(self):
+        assert detect_destructive_operation("/*! DROP TABLE users */", "mysql") == ("DROP", True)
+
+    def test_version_gated_executable_comment(self):
+        assert detect_destructive_operation("/*!50110 DROP TABLE users */", "mysql") == ("DROP", True)
+
+    def test_mariadb_executable_comment(self):
+        assert detect_destructive_operation("/*M! DELETE FROM users */", "mysql") == ("DELETE", True)
+
+    def test_executable_comment_fragment_inside_read(self):
+        sql = "SELECT * FROM t WHERE 1 /*! ; DELETE FROM t */"
+        assert detect_destructive_operation(sql, "mysql")[1] is True
+
+    def test_benign_executable_comment_is_read_only(self):
+        sql = "/*!40101 SET NAMES utf8 */; SELECT * FROM users"
+        assert detect_destructive_operation(sql, "mysql")[1] is False
+
+    def test_ordinary_block_comment_is_ignored(self):
+        assert detect_destructive_operation("SELECT 1 /* DROP TABLE users */")[1] is False
 
 
 class TestFalsePositiveGuards:
-    """Destructive words inside strings/identifiers must not trigger detection."""
-
-    def test_destructive_word_in_string_literal(self):
-        sql = "SELECT * FROM audit WHERE action = 'DELETE'"
-        assert detect_destructive_operation(sql) == ("SELECT", False)
-
-    def test_multiple_dml_words_in_string_literal(self):
-        sql = "SELECT * FROM audit WHERE action IN ('INSERT', 'UPDATE', 'DELETE')"
-        assert detect_destructive_operation(sql) == ("SELECT", False)
-
-    def test_escaped_quote_in_string_literal(self):
-        sql = "SELECT * FROM t WHERE note = 'it''s fine to DROP nothing'"
-        assert detect_destructive_operation(sql) == ("SELECT", False)
-
-    def test_destructive_word_in_double_quoted_identifier(self):
-        sql = 'SELECT "delete" FROM t'
-        assert detect_destructive_operation(sql) == ("SELECT", False)
-
-    def test_destructive_word_in_backtick_identifier(self):
-        sql = "SELECT `delete` FROM t"
-        assert detect_destructive_operation(sql) == ("SELECT", False)
+    """Destructive words inside strings/identifiers/functions stay read-only."""
 
     @pytest.mark.parametrize(
-        "sql",
+        "sql,dialect",
         [
-            "SELECT deleted_at FROM users",
-            "SELECT update_count FROM stats",
-            "SELECT insert_ts, is_deleted FROM events",
-            "SELECT createdby FROM records",
+            ("SELECT * FROM audit WHERE action = 'DELETE'", None),
+            ("SELECT * FROM audit WHERE action IN ('INSERT', 'UPDATE', 'DELETE')", None),
+            ("SELECT * FROM t WHERE note = 'it''s fine to DROP nothing'", None),
+            ('SELECT "delete" FROM t', None),
+            ("SELECT `delete` FROM t", "mysql"),
+            ("SELECT deleted_at, update_count, is_deleted FROM events", None),
+            ("SELECT REPLACE(name, 'a', 'b') FROM users", None),
+            ("SELECT INSERT(name, 1, 2, 'x') FROM users", "mysql"),
+            ("SELECT TRUNCATE(price, 2) FROM products", "mysql"),
         ],
     )
-    def test_destructive_word_as_identifier_substring(self, sql):
-        sql_type, is_destructive = detect_destructive_operation(sql)
-        assert is_destructive is False
-        assert sql_type == "SELECT"
+    def test_read_only_not_flagged(self, sql, dialect):
+        assert detect_destructive_operation(sql, dialect)[1] is False
+
+
+class TestConservativeFallback:
+    """Unparseable / opaque statements are treated as destructive."""
+
+    def test_unparseable_is_destructive(self):
+        assert detect_destructive_operation("!!! not valid sql @@@")[1] is True
+
+    def test_explain_analyze_write_is_destructive(self):
+        # EXPLAIN parses to an opaque Command whose payload is not introspectable,
+        # and EXPLAIN ANALYZE <write> executes, so treat it as destructive.
+        assert detect_destructive_operation("EXPLAIN ANALYZE DELETE FROM users", "postgresql")[1] is True
 
 
 class TestEdgeCases:
     """Empty / degenerate inputs."""
 
     @pytest.mark.parametrize("sql", ["", "   ", "\n\t", None])
-    def test_empty_or_none_is_not_destructive(self, sql):
+    def test_empty_or_none(self, sql):
         assert detect_destructive_operation(sql) == ("", False)
 
-    def test_only_comment_is_not_destructive(self):
-        assert detect_destructive_operation("-- nothing here") == ("", False)
+    def test_comment_only_is_not_destructive(self):
+        assert detect_destructive_operation("-- nothing here")[1] is False
+
+
+class TestDestructiveOpsConstant:
+    def test_core_verbs_present(self):
+        for verb in ("INSERT", "UPDATE", "DELETE", "DROP", "CREATE", "ALTER", "TRUNCATE", "REPLACE"):
+            assert verb in DESTRUCTIVE_OPS
 
 
 class TestConfirmationMessageIntegration:
@@ -188,83 +244,3 @@ class TestConfirmationMessageIntegration:
         message = build_destructive_confirmation_message(sql_type, sql)
         assert "DELETE" in message
         assert "DESTRUCTIVE OPERATION DETECTED" in message
-
-
-class TestReplaceStatement:
-    """MySQL ``REPLACE`` is a write (delete-then-insert) and must be caught,
-    but the same-named ``REPLACE()`` string function must not false-trigger."""
-
-    def test_replace_is_in_destructive_ops(self):
-        assert "REPLACE" in DESTRUCTIVE_OPS
-
-    def test_replace_into_is_destructive(self):
-        assert detect_destructive_operation("REPLACE INTO users VALUES (1, 'a')") == (
-            "REPLACE",
-            True,
-        )
-
-    def test_replace_into_via_cte_is_destructive(self):
-        sql = "WITH t AS (SELECT 1 AS id) REPLACE INTO users SELECT id FROM t"
-        assert detect_destructive_operation(sql) == ("REPLACE", True)
-
-    def test_replace_into_stacked_is_destructive(self):
-        assert detect_destructive_operation("SELECT 1; REPLACE INTO t VALUES (1)") == (
-            "REPLACE",
-            True,
-        )
-
-    @pytest.mark.parametrize(
-        "sql",
-        [
-            "SELECT REPLACE(name, 'a', 'b') FROM users",
-            "SELECT REPLACE (name, 'a', 'b') FROM users",  # space before paren
-            "SELECT id, INSERT(name, 1, 2, 'x') FROM users",  # MySQL INSERT() fn
-            "SELECT TRUNCATE(price, 2) FROM products",  # numeric TRUNCATE() fn
-        ],
-    )
-    def test_destructive_word_as_function_call_is_read_only(self, sql):
-        sql_type, is_destructive = detect_destructive_operation(sql)
-        assert is_destructive is False
-        assert sql_type == "SELECT"
-
-
-class TestExecutableComments:
-    """MySQL/MariaDB executable comments run on the server, so a destructive
-    verb inside one must be detected — not skipped like an ordinary comment."""
-
-    def test_executable_comment_drop_is_destructive(self):
-        assert detect_destructive_operation("/*! DROP TABLE users */") == ("DROP", True)
-
-    def test_executable_comment_leading_then_select(self):
-        # Executable comment with a destructive payload before a read.
-        sql = "/*! DELETE FROM users */ SELECT 1"
-        assert detect_destructive_operation(sql) == ("DELETE", True)
-
-    def test_version_gated_executable_comment_is_destructive(self):
-        assert detect_destructive_operation("/*!50110 DROP TABLE users */") == (
-            "DROP",
-            True,
-        )
-
-    def test_mariadb_executable_comment_is_destructive(self):
-        assert detect_destructive_operation("/*M! DELETE FROM users */") == (
-            "DELETE",
-            True,
-        )
-
-    def test_executable_comment_inside_statement_is_destructive(self):
-        sql = "SELECT 1 /*! ; DROP TABLE users */"
-        assert detect_destructive_operation(sql) == ("DROP", True)
-
-    def test_benign_executable_comment_is_read_only(self):
-        # SET is not destructive; the surrounding query is a read. (sql_type is
-        # unused for non-destructive results, so only is_destructive matters.)
-        sql = "/*!40101 SET NAMES utf8 */ SELECT * FROM users"
-        assert detect_destructive_operation(sql)[1] is False
-
-    def test_ordinary_block_comment_payload_stays_read_only(self):
-        # A non-executable /* ... */ comment must still be ignored.
-        assert detect_destructive_operation("SELECT 1 /* DROP TABLE users */") == (
-            "SELECT",
-            False,
-        )

--- a/tests/test_destructive_detection.py
+++ b/tests/test_destructive_detection.py
@@ -16,6 +16,8 @@ from api.core.pipeline import (
     detect_destructive_operation,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestPlainDestructiveOperations:
     """A statement that starts with a destructive verb is destructive."""
@@ -186,3 +188,83 @@ class TestConfirmationMessageIntegration:
         message = build_destructive_confirmation_message(sql_type, sql)
         assert "DELETE" in message
         assert "DESTRUCTIVE OPERATION DETECTED" in message
+
+
+class TestReplaceStatement:
+    """MySQL ``REPLACE`` is a write (delete-then-insert) and must be caught,
+    but the same-named ``REPLACE()`` string function must not false-trigger."""
+
+    def test_replace_is_in_destructive_ops(self):
+        assert "REPLACE" in DESTRUCTIVE_OPS
+
+    def test_replace_into_is_destructive(self):
+        assert detect_destructive_operation("REPLACE INTO users VALUES (1, 'a')") == (
+            "REPLACE",
+            True,
+        )
+
+    def test_replace_into_via_cte_is_destructive(self):
+        sql = "WITH t AS (SELECT 1 AS id) REPLACE INTO users SELECT id FROM t"
+        assert detect_destructive_operation(sql) == ("REPLACE", True)
+
+    def test_replace_into_stacked_is_destructive(self):
+        assert detect_destructive_operation("SELECT 1; REPLACE INTO t VALUES (1)") == (
+            "REPLACE",
+            True,
+        )
+
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "SELECT REPLACE(name, 'a', 'b') FROM users",
+            "SELECT REPLACE (name, 'a', 'b') FROM users",  # space before paren
+            "SELECT id, INSERT(name, 1, 2, 'x') FROM users",  # MySQL INSERT() fn
+            "SELECT TRUNCATE(price, 2) FROM products",  # numeric TRUNCATE() fn
+        ],
+    )
+    def test_destructive_word_as_function_call_is_read_only(self, sql):
+        sql_type, is_destructive = detect_destructive_operation(sql)
+        assert is_destructive is False
+        assert sql_type == "SELECT"
+
+
+class TestExecutableComments:
+    """MySQL/MariaDB executable comments run on the server, so a destructive
+    verb inside one must be detected — not skipped like an ordinary comment."""
+
+    def test_executable_comment_drop_is_destructive(self):
+        assert detect_destructive_operation("/*! DROP TABLE users */") == ("DROP", True)
+
+    def test_executable_comment_leading_then_select(self):
+        # Executable comment with a destructive payload before a read.
+        sql = "/*! DELETE FROM users */ SELECT 1"
+        assert detect_destructive_operation(sql) == ("DELETE", True)
+
+    def test_version_gated_executable_comment_is_destructive(self):
+        assert detect_destructive_operation("/*!50110 DROP TABLE users */") == (
+            "DROP",
+            True,
+        )
+
+    def test_mariadb_executable_comment_is_destructive(self):
+        assert detect_destructive_operation("/*M! DELETE FROM users */") == (
+            "DELETE",
+            True,
+        )
+
+    def test_executable_comment_inside_statement_is_destructive(self):
+        sql = "SELECT 1 /*! ; DROP TABLE users */"
+        assert detect_destructive_operation(sql) == ("DROP", True)
+
+    def test_benign_executable_comment_is_read_only(self):
+        # SET is not destructive; the surrounding query is a read. (sql_type is
+        # unused for non-destructive results, so only is_destructive matters.)
+        sql = "/*!40101 SET NAMES utf8 */ SELECT * FROM users"
+        assert detect_destructive_operation(sql)[1] is False
+
+    def test_ordinary_block_comment_payload_stays_read_only(self):
+        # A non-executable /* ... */ comment must still be ignored.
+        assert detect_destructive_operation("SELECT 1 /* DROP TABLE users */") == (
+            "SELECT",
+            False,
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -2182,6 +2182,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pymysql" },
     { name = "python-dotenv" },
+    { name = "sqlglot" },
     { name = "tqdm" },
 ]
 
@@ -2275,6 +2276,7 @@ requires-dist = [
     { name = "python-multipart", marker = "extra == 'server'", specifier = "~=0.0.32" },
     { name = "snowflake-connector-python", marker = "extra == 'all'", specifier = "~=4.6.0" },
     { name = "snowflake-connector-python", marker = "extra == 'server'", specifier = "~=4.6.0" },
+    { name = "sqlglot", specifier = ">=30.12.0" },
     { name = "tqdm", specifier = ">=4.67.3,<4.69.0" },
     { name = "uvicorn", marker = "extra == 'all'", specifier = ">=0.46,<0.52" },
     { name = "uvicorn", marker = "extra == 'server'", specifier = ">=0.46,<0.52" },
@@ -2624,6 +2626,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "sqlglot"
+version = "30.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/ed/a6c45aec29353b6392ea34548c40af3ac6ffd6bc5572cf23b2ce250876fc/sqlglot-30.12.0.tar.gz", hash = "sha256:6b8369704662d4f654bc934cea4dd31c916c2a571b389210cb9e951a275e5fd9", size = 5905110, upload-time = "2026-06-26T14:09:40.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/9e/82a390ecc85f066ff80affa01d195f744e3de60ad4d695b8de31c9a66da3/sqlglot-30.12.0-py3-none-any.whl", hash = "sha256:86cccc610073c645c03e72b55b60ae0518aa3253a7fc3bd56551370d003c6554", size = 707583, upload-time = "2026-06-26T14:09:38.525Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes a **destructive-operation confirmation bypass** in `api/core/pipeline.py`. `detect_destructive_operation()` classified SQL by its **first token only**, so data-modifying CTEs, stacked statements, executable comments, and dialect escape/quote/comment tricks could execute a write **without the confirmation dialog** and **bypass the demo-graph read-only guard**.

Found during the rubber-duck review of #643.

## The vulnerability

```sql
WITH doomed AS (SELECT id FROM users WHERE inactive)
DELETE FROM users WHERE id IN (SELECT id FROM doomed)
```

First token is `WITH`, so the old check returned `("WITH", False)` → no confirmation, and it ran even on read-only demo graphs. Stacked statements (`SELECT 1; DROP TABLE users`) had the same flaw.

## The fix — dialect-aware parsing, **fail-closed**

A hand-rolled lexical scanner can't be correct across MySQL/Postgres/Snowflake (backslash escapes, dollar quoting, `#`/nested comments), so detection now uses **`sqlglot`** (dialect-aware, from `db_type`) with a **fail-closed** policy:

- A statement is **non-destructive only if** it parses, every statement's **root** is a known read-only type (`Select`, `Union`, `Intersect`, `Except`, `Values`, `Show`, `Describe`), **and** no nested node is a write/DDL/privilege/bulk op (`Insert/Update/Delete/Merge/Drop/Create/Alter/Truncate/Copy/Grant/Revoke/Into/Comment`, incl. inside CTEs/subqueries).
- **Everything else is destructive** — writes/DDL, `SELECT … INTO`, `MERGE`, `REPLACE`, `GRANT/REVOKE`, `COPY/LOAD`, `RENAME`, `CALL`, `DO`, stacked statements, generically-parsed commands (`RESET`, `SHUTDOWN`, `UNDROP`, `CLUSTER`, `SET GLOBAL/PERSIST`, `EXPLAIN ANALYZE …`), and anything unparseable.
- **MySQL executable comments** (`/*! … */`, `/*M! … */`): sqlglot drops them as ordinary comments, and a comment/string-blind textual rewrite can be bypassed (a marker hidden in a string literal mispairing with an unrelated `*/`). So for MySQL/unknown dialects we **fail safe on the marker's mere presence**. (For Postgres/Snowflake, `/*! */` is a normal comment.)

The reported `sql_type` names the operation for the confirmation message. Both call sites (`run_query` and the healer execute-guard) pass `db_type`.

### Now correctly classified

| SQL | before | after |
|---|---|---|
| `WITH t AS (…) DELETE FROM users …` | `("WITH", False)` ❌ | `("DELETE", True)` ✅ |
| `SELECT 1; DROP TABLE users` | `("SELECT", False)` ❌ | `("DROP", True)` ✅ |
| `/*! DROP TABLE users */` (mysql) | not detected ❌ | destructive ✅ |
| `WITH cte AS (SELECT $$'$$ AS s) DELETE …` (pg) | bypass ❌ | `("DELETE", True)` ✅ |
| `REPLACE INTO …` / `MERGE` / `GRANT` / `SELECT … INTO` / `CALL` / `COPY` / `LOAD DATA` | not detected ❌ | destructive ✅ |
| `RESET MASTER` / `SHUTDOWN` / `UNDROP TABLE` / `CLUSTER` / `SET GLOBAL …` | fail-open ❌ | destructive ✅ |
| `SELECT REPLACE(name,'a','b')` / `SELECT 'DELETE'` / `deleted_at` / `SHOW TABLES` | read-only ✅ | read-only ✅ |

### Defense in depth

The healer's execute callback rejects destructive **healed** SQL instead of running it (LLM output is not a security boundary).

### Known limitation (documented in code)

A side-effecting routine shaped like a read — `SELECT setval(...)`, `SELECT my_mutating_func()` — is indistinguishable from a pure read by SQL shape alone and is **not** caught here. Enforce that with database-level read-only transactions/credentials.

## Tests

`tests/test_destructive_detection.py` — **72 cases**: plain writes, read-only reads, CTE/stacked bypasses, extra mutators, dialect escape bypasses, executable-comment fail-safe, fail-closed roots (`RESET/SHUTDOWN/UNDROP/CLUSTER/SET GLOBAL/…`), false-positive guards (string/identifier/function words), conservative fallback, and confirmation-message integration.

## Verification

- `pylint` → **10.00/10**; `pytest tests/test_destructive_detection.py` → **72 passed**
- `uv sync --locked` consistent (adds `sqlglot`); full CI green
- Rebased on staging (linear history); all Copilot/CodeRabbit threads replied + resolved.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
