### PR TITLE
chore(release): bump version 0.3.0 → 0.3.1

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "queryweaver-app",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "queryweaver-app",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@falkordb/canvas": "^0.0.45",
         "@hookform/resolvers": "^5.2.2",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "queryweaver-app",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/queryweaver/__init__.py
+++ b/queryweaver/__init__.py
@@ -50,4 +50,4 @@ __all__ = [
     "FalkorDBConnection",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"


### PR DESCRIPTION
## Summary

Version bump **0.3.0 → 0.3.1** to prepare a tagged release that carries the **CVE-2026-10130** fix.

The fix (auth bypass via signup token issuance for existing accounts — commit `8074483`, "fix(auth): prevent signup token issuance for existing accounts") is already merged on both `staging` and `main`, but **no released tag or published Docker image contains it yet** — the latest release is `0.0.14` (2026-01-08), which predates the fix. This bump gives us a version to tag and ship.

## Changes

- `queryweaver/__init__.py`: `__version__` `0.3.0` → `0.3.1` (single source; PyPI + `/version` derive from here)
- `app/package.json` + `app/package-lock.json`: `0.3.0` → `0.3.1`
- `server.json` intentionally **left at `0.0.11`** — its realignment is deferred to the release-management branch.

## Release path

1. Merge this into `staging`.
2. Open `staging → main` PR (separate, by @galshubeli).
3. Cut a GitHub release tagged `0.3.1` off `main` → triggers the Docker image build/push (and PyPI publish) containing the fix.
4. Confirm prod (`app.queryweaver.ai`) redeploys onto the new image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.3.1.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->