### PR TITLE
chore: address PR #613 review nits (test PII + meta docstring)

### DIFF
--- a/api/routes/meta.py
+++ b/api/routes/meta.py
@@ -1,4 +1,4 @@
-"""Public metadata routes (version/health) for the QueryWeaver API.
+"""Public metadata route (``/version``) for the QueryWeaver API.
 
 These endpoints are intentionally unauthenticated so the frontend can read
 them before login. Their tag is not mapped to any MCP type, so FastMCP's

--- a/tests/test_usage_tracking.py
+++ b/tests/test_usage_tracking.py
@@ -21,7 +21,7 @@ from api.routes.usage_tracking import (
 
 pytestmark = [pytest.mark.unit]
 
-EMAIL = "gal.shubeli@falkordb.com"
+EMAIL = "test.user@example.com"
 USER_ID = base64.b64encode(EMAIL.encode()).decode()
 
 


### PR DESCRIPTION
## Summary

Two low-risk cleanups surfaced by the automated review of the staging→main release PR (#613). The remaining automated findings were verified as **false positives** and left unchanged (rationale below + replied on #613).

## Fixed

- **`tests/test_usage_tracking.py`** — the `USER_ID` fixture was built from a real employee email (`gal.shubeli@falkordb.com`). Replaced with a fictitious `test.user@example.com`; base64 behaviour is identical. (Copilot)
- **`api/routes/meta.py`** — module docstring referenced `version/health`, but only `/version` exists. Aligned the docstring with the actual route surface. (Copilot)

`pytest tests/test_usage_tracking.py tests/test_meta_route.py` → 13 passed.

## Verified false positives (no change)

- **`openai` missing from `[server]` extra → `use_memory` ImportError** (Copilot): `graphiti-core` 0.29.1 declares `openai` as a **core** dependency, so `queryweaver[server]` installs it transitively. `from openai import AsyncAzureOpenAI` always resolves.
- **PyPI publish can bypass TestPyPI gate on reruns** (overcut-ai): the workflow already builds once in a dedicated `build` job, uploads the artifact, and both publish jobs consume that same artifact; `needs:` is success-gated by default and each publish job is behind a protected `environment`.
- **Vite dev proxy missing `/version`** (overcut-ai): the frontend calls `buildApiUrl('/version')`, which resolves to `/api/version` on the dev server (`BASE_URL='/api'`) and is forwarded by the existing `/api` proxy. Works in dev as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated public metadata route documentation to accurately describe the available version endpoint.

* **Tests**
  * Updated usage-tracking test data to use a generic example email address and its corresponding identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->