### PR TITLE
ci(pypi): drop TestPyPI dry-run gate, publish straight from build

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,13 +1,10 @@
 name: Publish to PyPI
 
 # Builds the queryweaver wheel/sdist ONCE, then publishes that exact artifact
-# via PyPI Trusted Publishing (OIDC) — no API tokens are stored. The same build
-# is validated on TestPyPI as a dry-run gate first, then shipped to PyPI only if
-# that succeeds.
+# to PyPI via Trusted Publishing (OIDC) — no API tokens are stored.
 #
-# One-time setup (see plan): configure a Trusted Publisher on both PyPI and
-# TestPyPI for repo FalkorDB/QueryWeaver, workflow publish-pypi.yml, with the
-# GitHub environments `testpypi` and `pypi` respectively.
+# One-time setup: configure a Trusted Publisher on PyPI for repo
+# FalkorDB/QueryWeaver, workflow publish-pypi.yml, GitHub environment `pypi`.
 
 permissions:
   contents: read
@@ -37,32 +34,9 @@ jobs:
           name: dist
           path: dist/
 
-  publish-testpypi:
-    name: Publish to TestPyPI (dry-run gate)
-    needs: build
-    runs-on: ubuntu-latest
-    environment: testpypi
-    permissions:
-      id-token: write   # required for OIDC trusted publishing
-      contents: read
-    steps:
-      - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-        with:
-          enable-cache: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: dist
-          path: dist/
-      - name: Publish to TestPyPI
-        run: >
-          uv publish
-          --publish-url https://test.pypi.org/legacy/
-          --trusted-publishing always
-          --check-url https://test.pypi.org/simple/
-
   publish-pypi:
     name: Publish to PyPI
-    needs: publish-testpypi
+    needs: build
     runs-on: ubuntu-latest
     environment: pypi
     permissions:


### PR DESCRIPTION
## Summary

Simplifies the PyPI publish workflow to **`build` → `publish-pypi`**. Removes the `publish-testpypi` job and repoints `publish-pypi`'s `needs` from `publish-testpypi` to `build`.

## Why

The 0.3.1 release failed at the TestPyPI dry-run gate with `invalid-publisher` — that stage needed a **second** Trusted Publisher registration (GitHub environment `testpypi`) that was never configured. Dropping the gate leaves a single publish path that only needs the **PyPI** Trusted Publisher (environment `pypi`), halving the one-time setup.

The build is still produced once and the exact artifact is published; only the TestPyPI validation hop is removed.

## Still required before a green publish

1. Register a Trusted Publisher on **PyPI** for the `queryweaver` project: owner `FalkorDB`, repo `QueryWeaver`, workflow `publish-pypi.yml`, environment `pypi`.
2. Ensure the GitHub `pypi` environment exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the package publishing workflow by removing the TestPyPI validation step.
  * Packages are now built once and published directly to PyPI using trusted publishing.
  * Updated workflow documentation to reflect the revised release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->