### PR TITLE
test: harden E2E confirmation waits and add API route tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install test test-unit test-e2e test-e2e-no-ai test-e2e-headed lint format clean setup-dev build lint-frontend test-sdk docker-test-services docker-test-stop build-package
+.PHONY: help install test test-unit test-e2e test-e2e-no-ai test-e2e-headed e2e-deps lint format clean setup-dev build lint-frontend test-sdk docker-test-services docker-test-stop build-package
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'
@@ -8,6 +8,7 @@ help: ## Show this help message
 
 install: ## Install dependencies
 	uv sync
+	npm ci
 	npm ci --prefix ./app
 
 
@@ -33,19 +34,24 @@ test-unit: ## Run unit tests only (excludes SDK and E2E tests)
 	uv run python -m pytest tests/ -k "not e2e and not test_sdk" --ignore=tests/test_sdk --verbose
 
 
-test-e2e: build-dev ## Run E2E tests headless
+# Playwright lives in the root package.json; without it `npx` would silently
+# fetch an unpinned version instead of the one in package-lock.json.
+e2e-deps:
+	@[ -x node_modules/.bin/playwright ] || npm ci
+
+test-e2e: build-dev e2e-deps ## Run E2E tests headless
 	npx playwright test --reporter=list
 
 
-test-e2e-no-ai: build-dev ## Run E2E tests that do not need LLM secrets
+test-e2e-no-ai: build-dev e2e-deps ## Run E2E tests that do not need LLM secrets
 	npx playwright test --grep-invert @requires-ai --reporter=list
 
 
-test-e2e-headed: build-dev ## Run E2E tests with browser visible
+test-e2e-headed: build-dev e2e-deps ## Run E2E tests with browser visible
 	npx playwright test --headed --reporter=list
 
 
-test-e2e-debug: build-dev ## Run E2E tests with debugging enabled
+test-e2e-debug: build-dev e2e-deps ## Run E2E tests with debugging enabled
 	npx playwright test --debug
 
 lint: ## Run linting (backend + frontend)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install test test-unit test-e2e test-e2e-headed lint format clean setup-dev build lint-frontend test-sdk docker-test-services docker-test-stop build-package
+.PHONY: help install test test-unit test-e2e test-e2e-no-ai test-e2e-headed lint format clean setup-dev build lint-frontend test-sdk docker-test-services docker-test-stop build-package
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'
@@ -34,15 +34,19 @@ test-unit: ## Run unit tests only (excludes SDK and E2E tests)
 
 
 test-e2e: build-dev ## Run E2E tests headless
-	uv run python -m pytest tests/e2e/ --browser chromium --video=on --screenshot=on
+	npx playwright test --reporter=list
+
+
+test-e2e-no-ai: build-dev ## Run E2E tests that do not need LLM secrets
+	npx playwright test --grep-invert @requires-ai --reporter=list
 
 
 test-e2e-headed: build-dev ## Run E2E tests with browser visible
-	uv run python -m pytest tests/e2e/ --browser chromium --headed
+	npx playwright test --headed --reporter=list
 
 
 test-e2e-debug: build-dev ## Run E2E tests with debugging enabled
-	uv run python -m pytest tests/e2e/ --browser chromium --slowmo=1000
+	npx playwright test --debug
 
 lint: ## Run linting (backend + frontend)
 	@echo "Running backend lint (pylint)"
@@ -59,7 +63,7 @@ format: ## Format code (placeholder - add black/autopep8 if needed)
 clean: ## Clean up test artifacts
 	rm -rf test-results/
 	rm -rf playwright-report/
-	rm -rf tests/e2e/screenshots/
+	rm -rf e2e/.auth/
 	rm -rf __pycache__/
 	rm -rf dist/
 	rm -rf *.egg-info/

--- a/e2e/infra/utils.ts
+++ b/e2e/infra/utils.ts
@@ -1,5 +1,4 @@
-import { Locator } from "playwright";
-import { expect } from "@playwright/test";
+import { Locator, expect } from "@playwright/test";
 
 export function delay(ms: number) {
   return new Promise((resolve) => {

--- a/e2e/infra/utils.ts
+++ b/e2e/infra/utils.ts
@@ -1,4 +1,5 @@
 import { Locator } from "playwright";
+import { expect } from "@playwright/test";
 
 export function delay(ms: number) {
   return new Promise((resolve) => {
@@ -6,22 +7,20 @@ export function delay(ms: number) {
   });
 }
 
+// `time` and `retry` are kept for call-site compatibility: they define the total budget.
+const budget = (time: number, retry: number) => time * retry;
+
 export const waitForElementToBeVisible = async (
   locator: Locator,
   time = 500,
   retry = 10
 ): Promise<boolean> => {
-  for (let i = 0; i < retry; i += 1) {
-    try {
-      if (await locator.isVisible()) {
-        return true;
-      }
-    } catch (error) {
-      console.error(`Error checking element visibility: ${error}`);
-    }
-    await delay(time);
+  try {
+    await locator.waitFor({ state: "visible", timeout: budget(time, retry) });
+    return true;
+  } catch {
+    return false;
   }
-  return false;
 };
 
 export const waitForElementToNotBeVisible = async (
@@ -29,17 +28,12 @@ export const waitForElementToNotBeVisible = async (
   time = 500,
   retry = 10
 ): Promise<boolean> => {
-  for (let i = 0; i < retry; i += 1) {
-    try {
-      if (!(await locator.isVisible())) {
-        return true;
-      }
-    } catch (error) {
-      console.error(`Error checking element visibility: ${error}`);
-    }
-    await delay(time);
+  try {
+    await locator.waitFor({ state: "hidden", timeout: budget(time, retry) });
+    return true;
+  } catch {
+    return false;
   }
-  return false;
 };
 
 export const waitForElementToBeEnabled = async (
@@ -47,17 +41,12 @@ export const waitForElementToBeEnabled = async (
   time = 500,
   retry = 10
 ): Promise<boolean> => {
-  for (let i = 0; i < retry; i += 1) {
-    try {
-      if (await locator.isEnabled()) {
-        return true;
-      }
-    } catch (error) {
-      console.error(`Error checking element enabled: ${error}`);
-    }
-    await delay(time);
+  try {
+    await expect(locator).toBeEnabled({ timeout: budget(time, retry) });
+    return true;
+  } catch {
+    return false;
   }
-  return false;
 };
 
 export function getRandomString(prefix = "", delimiter = "_"): string {

--- a/e2e/logic/pom/homePage.ts
+++ b/e2e/logic/pom/homePage.ts
@@ -994,7 +994,7 @@ export class HomePage extends BasePage {
    * Uses longer timeout than existing methods since AI responses can be slow
    */
   async waitForAIMessage(timeoutMs: number = 30000): Promise<boolean> {
-    return await waitForElementToBeVisible(this.aiMessage, 1000, timeoutMs / 1000);
+    return await waitForElementToBeVisible(this.aiMessage, timeoutMs, 1);
   }
 
   /**
@@ -1059,7 +1059,7 @@ export class HomePage extends BasePage {
    * Wait for toast to appear
    */
   async waitForToast(timeoutMs: number = 5000): Promise<boolean> {
-    return await waitForElementToBeVisible(this.toastNotification, 1000, timeoutMs / 1000);
+    return await waitForElementToBeVisible(this.toastNotification, timeoutMs, 1);
   }
 
   /**
@@ -1155,9 +1155,21 @@ export class HomePage extends BasePage {
   /**
    * Wait for confirmation message to appear
    */
-  async waitForConfirmationMessage(timeout: number = 10000): Promise<boolean> {
+  async waitForConfirmationMessage(timeout: number = 30000): Promise<boolean> {
     try {
       await this.confirmationMessage.waitFor({ state: 'visible', timeout });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Wait for the confirmation message to disappear after confirming/cancelling
+   */
+  async waitForConfirmationToDisappear(timeout: number = 30000): Promise<boolean> {
+    try {
+      await this.confirmationMessage.waitFor({ state: 'hidden', timeout });
       return true;
     } catch {
       return false;

--- a/e2e/logic/pom/userProfile.ts
+++ b/e2e/logic/pom/userProfile.ts
@@ -1,4 +1,4 @@
-import { Locator } from "@playwright/test";
+import { Locator, expect } from "@playwright/test";
 import { waitForElementToBeVisible } from "../../infra/utils";
 import BasePage from "../../infra/ui/basePage";
 
@@ -320,15 +320,29 @@ export class UserProfile extends BasePage {
     return await waitForElementToBeVisible(this.deleteTokenConfirmDialog);
   }
 
+  private get tokenRows(): Locator {
+    return this.page.locator('[data-testid^="token-row-"]');
+  }
+
+  /**
+   * Waits until at least `minCount` token rows are rendered. The tokens table
+   * re-renders after each generate call, so callers that just created tokens
+   * must wait for them instead of snapshotting whatever is on screen.
+   */
+  async waitForTokenRows(minCount: number, timeout: number = 10000): Promise<void> {
+    await expect
+      .poll(async () => await this.tokenRows.count(), { timeout })
+      .toBeGreaterThanOrEqual(minCount);
+  }
+
   async getAllTokenRows(): Promise<Locator[]> {
-    // Try to wait for token rows, but don't fail if none exist
+    // Wait for the table to settle, but don't fail if it is legitimately empty.
     try {
-      await this.page.waitForSelector('[data-testid^="token-row-"]', { timeout: 5000 });
+      await this.waitForTokenRows(1, 5000);
     } catch {
-      // No token rows found, return empty array
       return [];
     }
-    return await this.page.locator('[data-testid^="token-row-"]').all();
+    return await this.tokenRows.all();
   }
 
   async getTokenCount(): Promise<number> {

--- a/e2e/tests/chat.spec.ts
+++ b/e2e/tests/chat.spec.ts
@@ -242,6 +242,7 @@ test.describe('Chat Feature Tests', () => {
   });
 
   test('destructive operation shows inline confirmation and executes on confirm', { tag: '@requires-ai' }, async () => {
+    test.slow(); // 30s confirmation wait + 50s processing wait exceeds the 60s describe budget
     const homePage = await browser.createNewPage(HomePage, getBaseUrl(), 'e2e/.auth/user.json');
     await browser.setPageToFullScreen();
 
@@ -275,8 +276,8 @@ test.describe('Chat Feature Tests', () => {
     expect(processingComplete).toBeTruthy();
 
     // Verify confirmation message is no longer visible
-    const confirmationStillVisible = await homePage.isConfirmationMessageVisible();
-    expect(confirmationStillVisible).toBeFalsy();
+    const confirmationDismissed = await homePage.waitForConfirmationToDisappear();
+    expect(confirmationDismissed).toBeTruthy();
 
     // Verify AI response appears after confirmation
     const finalAIMessageCount = await homePage.getAIMessageCount();

--- a/e2e/tests/userProfile.spec.ts
+++ b/e2e/tests/userProfile.spec.ts
@@ -256,6 +256,7 @@ test.describe('User Profile Tests', () => {
     const secondTokenId = userProfile.extractTokenId(secondTokenValue || '');
 
     // Verify both tokens exist in the list by their IDs
+    await userProfile.waitForTokenRows(2);
     const tokenIds = await userProfile.getTokenIdsFromRows();
     expect(tokenIds).toContain(firstTokenId);
     expect(tokenIds).toContain(secondTokenId);

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -2,7 +2,11 @@
 
 Every route is exercised through ``TestClient`` with the core layer mocked, so
 these tests cover the HTTP contract — status codes, response bodies and the
-streaming wire format — without a live database or LLM.
+streaming wire format — without reaching a real database or LLM.
+
+A FalkorDB instance must still be reachable to *import* the app: importing
+``api.index`` pulls in ``api/extensions.py``, which opens a connection at
+import time. CI provides one as a service container.
 
 Requests authenticate with a Bearer token: ``CSRFMiddleware`` exempts
 Bearer-authenticated requests, so the tests assert authorization behaviour

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1,0 +1,542 @@
+"""Request/response tests for the REST routes under ``api/routes/``.
+
+Every route is exercised through ``TestClient`` with the core layer mocked, so
+these tests cover the HTTP contract — status codes, response bodies and the
+streaming wire format — without a live database or LLM.
+
+Requests authenticate with a Bearer token: ``CSRFMiddleware`` exempts
+Bearer-authenticated requests, so the tests assert authorization behaviour
+rather than re-testing CSRF (see ``test_csrf_middleware.py``).
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.core.errors import GraphNotFoundError, InternalError, InvalidArgumentError
+from api.core.pipeline import MESSAGE_DELIMITER
+from api.index import app
+
+USER_EMAIL = "tester@example.com"
+BEARER = {"Authorization": "Bearer test-token"}
+
+# (method, path, json body) for every route guarded by ``token_required``.
+# Bodies are valid so the request reaches the auth decorator instead of
+# failing FastAPI's request validation with a 422.
+PROTECTED_ROUTES = [
+    ("GET", "/graphs", None),
+    ("POST", "/graphs", {"database": "testdb"}),
+    ("GET", "/graphs/testdb/data", None),
+    ("DELETE", "/graphs/testdb", None),
+    ("POST", "/graphs/testdb", {"chat": ["show me users"]}),
+    ("POST", "/graphs/testdb/confirm", {"sql_query": "DELETE FROM users"}),
+    ("POST", "/graphs/testdb/refresh", None),
+    ("GET", "/graphs/testdb/user-rules", None),
+    ("PUT", "/graphs/testdb/user-rules", {"user_rules": "be brief"}),
+    ("POST", "/database", {"url": "postgresql://u:p@localhost:5432/testdb"}),
+    ("GET", "/tokens/list", None),
+    ("POST", "/tokens/generate", None),
+    ("DELETE", "/tokens/abcd", None),
+    ("POST", "/settings/validate-api-key", {"api_key": "sk-test"}),
+]
+
+
+async def _agen(*items):
+    """Build an async generator yielding ``items``."""
+    for item in items:
+        yield item
+
+
+def _final(**kwargs):
+    """A stand-in for the pipeline's terminal ``QueryResult``."""
+    return SimpleNamespace(
+        requires_confirmation=False, is_valid=True, error_message=None, **kwargs
+    )
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    """Test client for the assembled FastAPI app."""
+    return TestClient(app)
+
+
+@pytest.fixture(name="authed")
+def authed_fixture():
+    """Make the Bearer token resolve to an authenticated user."""
+    with patch(
+        "api.auth.user_management.validate_user",
+        new=AsyncMock(return_value=({"email": USER_EMAIL}, True)),
+    ):
+        yield
+
+
+@pytest.fixture(name="no_usage_tracking")
+def no_usage_tracking_fixture():
+    """Stop streaming routes from recording usage against the graph DB."""
+    with patch("api.routes.graphs.record_query_usage_background") as mock:
+        yield mock
+
+
+def _request(client, method, path, body=None, headers=None):
+    """Issue a request, sending ``body`` as JSON when the method allows it."""
+    kwargs = {"headers": headers or {}}
+    if body is not None:
+        kwargs["json"] = body
+    return client.request(method, path, **kwargs)
+
+
+def _stream_events(response):
+    """Decode a delimiter-separated streaming response into event dicts."""
+    return [
+        json.loads(chunk)
+        for chunk in response.text.split(MESSAGE_DELIMITER)
+        if chunk.strip()
+    ]
+
+
+class TestAuthorization:
+    """Every route under ``api/routes/`` that requires a token."""
+
+    @pytest.mark.parametrize(
+        "method,path,body",
+        PROTECTED_ROUTES,
+        ids=[f"{m} {p}" for m, p, _ in PROTECTED_ROUTES],
+    )
+    def test_rejects_unknown_token(self, client, method, path, body):
+        """An unrecognised Bearer token must yield 401, never 5xx."""
+        with patch(
+            "api.auth.user_management._get_user_info", new=AsyncMock(return_value=None)
+        ):
+            response = _request(client, method, path, body, BEARER)
+
+        assert response.status_code == 401
+        assert "Unauthorized" in response.json()["detail"]
+
+    def test_version_is_public(self, client):
+        """``/version`` is intentionally unauthenticated."""
+        response = client.get("/version")
+
+        assert response.status_code == 200
+        assert response.json()["name"] == "queryweaver"
+        assert response.json()["version"]
+
+
+@pytest.mark.usefixtures("authed")
+class TestGraphsRoutes:
+    """``api/routes/graphs.py``."""
+
+    def test_list_graphs(self, client):
+        """Returns the user's databases verbatim."""
+        with patch(
+            "api.routes.graphs.list_databases",
+            new=AsyncMock(return_value=["testdb", "sales"]),
+        ):
+            response = client.get("/graphs", headers=BEARER)
+
+        assert response.status_code == 200
+        assert response.json() == ["testdb", "sales"]
+
+    def test_get_graph_data(self, client):
+        """Returns the schema as-is."""
+        schema = {"nodes": [{"id": 1}], "edges": []}
+        with patch("api.routes.graphs.get_schema", new=AsyncMock(return_value=schema)):
+            response = client.get("/graphs/testdb/data", headers=BEARER)
+
+        assert response.status_code == 200
+        assert response.json() == schema
+
+    @pytest.mark.parametrize(
+        "error,status,message",
+        [
+            (GraphNotFoundError("missing"), 404, "Database not found"),
+            (InternalError("boom"), 500, "Failed to retrieve database schema"),
+        ],
+    )
+    def test_get_graph_data_errors(self, client, error, status, message):
+        """Core errors map to status codes without leaking details."""
+        with patch(
+            "api.routes.graphs.get_schema", new=AsyncMock(side_effect=error)
+        ):
+            response = client.get("/graphs/testdb/data", headers=BEARER)
+
+        assert response.status_code == status
+        assert response.json() == {"error": message}
+
+    def test_delete_graph(self, client):
+        """Successful deletion passes the core result through."""
+        with patch(
+            "api.routes.graphs.delete_database",
+            new=AsyncMock(return_value={"deleted": "testdb"}),
+        ):
+            response = client.delete("/graphs/testdb", headers=BEARER)
+
+        assert response.status_code == 200
+        assert response.json() == {"deleted": "testdb"}
+
+    @pytest.mark.parametrize(
+        "error,status,message",
+        [
+            (InvalidArgumentError("bad"), 400, "Invalid delete request"),
+            (GraphNotFoundError("missing"), 404, "Database not found"),
+            (InternalError("boom"), 500, "Failed to delete database"),
+        ],
+    )
+    def test_delete_graph_errors(self, client, error, status, message):
+        """Core errors map to status codes without leaking details."""
+        with patch(
+            "api.routes.graphs.delete_database", new=AsyncMock(side_effect=error)
+        ):
+            response = client.delete("/graphs/testdb", headers=BEARER)
+
+        assert response.status_code == status
+        assert response.json() == {"error": message}
+
+    @pytest.mark.parametrize(
+        "filename,status",
+        [
+            ("schema.json", 501),
+            ("schema.xml", 501),
+            ("schema.csv", 501),
+            ("schema.txt", 415),
+        ],
+    )
+    def test_load_graph_upload(self, client, filename, status):
+        """Loaders are not implemented yet; unknown extensions are rejected."""
+        response = client.post(
+            "/graphs",
+            headers=BEARER,
+            files={"file": (filename, b"payload", "application/octet-stream")},
+        )
+
+        assert response.status_code == status
+
+    def test_load_graph_json_payload(self, client):
+        """A JSON body never reaches the loader: ``File(None)`` forces multipart parsing."""
+        response = client.post("/graphs", headers=BEARER, json={"database": "testdb"})
+
+        assert response.status_code == 415
+
+    def test_load_graph_without_payload(self, client):
+        """No body and no file is an unsupported content type."""
+        response = client.post("/graphs", headers=BEARER)
+
+        assert response.status_code == 415
+
+    @pytest.mark.usefixtures("no_usage_tracking")
+    def test_query_graph_streams_events(self, client):
+        """Pipeline events are streamed delimiter-separated, minus the sentinel."""
+        from api.routes.graphs import _Final  # pylint: disable=import-outside-toplevel
+
+        with patch(
+            "api.routes.graphs.run_query",
+            return_value=_agen({"type": "progress"}, _Final(_final())),
+        ):
+            response = client.post(
+                "/graphs/testdb", headers=BEARER, json={"chat": ["show me users"]}
+            )
+
+        assert response.status_code == 200
+        assert _stream_events(response) == [{"type": "progress"}]
+
+    def test_query_graph_rejects_invalid_chat(self, client):
+        """Client-side validation errors surface as 400, not a broken stream."""
+        with patch(
+            "api.routes.graphs.validate_and_truncate_chat",
+            side_effect=InvalidArgumentError("empty chat"),
+        ):
+            response = client.post("/graphs/testdb", headers=BEARER, json={"chat": []})
+
+        assert response.status_code == 400
+        assert response.json() == {"error": "Invalid query request"}
+
+    def test_confirm_rejects_empty_sql(self, client):
+        """A confirmation with no SQL is rejected before streaming starts."""
+        response = client.post(
+            "/graphs/testdb/confirm", headers=BEARER, json={"sql_query": "   "}
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {"error": "Invalid confirmation request"}
+
+    @pytest.mark.usefixtures("no_usage_tracking")
+    def test_confirm_streams_events(self, client):
+        """Confirmed destructive operations stream like a normal query."""
+        from api.routes.graphs import _Final  # pylint: disable=import-outside-toplevel
+
+        with patch(
+            "api.routes.graphs.run_confirmed",
+            return_value=_agen({"type": "executing"}, _Final(_final())),
+        ):
+            response = client.post(
+                "/graphs/testdb/confirm",
+                headers=BEARER,
+                json={"sql_query": "DELETE FROM users", "chat": ["drop them"]},
+            )
+
+        assert response.status_code == 200
+        assert _stream_events(response) == [{"type": "executing"}]
+
+    def test_refresh_schema_streams(self, client):
+        """A refresh returns the loader's progress stream."""
+        with patch(
+            "api.routes.graphs.refresh_database_schema",
+            new=AsyncMock(return_value=_agen("chunk")),
+        ):
+            response = client.post("/graphs/testdb/refresh", headers=BEARER)
+
+        assert response.status_code == 200
+        assert response.text == "chunk"
+
+    @pytest.mark.parametrize(
+        "error,status,message",
+        [
+            (InvalidArgumentError("bad"), 400, "Invalid request to refresh schema"),
+            (InternalError("boom"), 500, "Failed to refresh database schema"),
+        ],
+    )
+    def test_refresh_schema_errors(self, client, error, status, message):
+        """Core errors map to status codes without leaking details."""
+        with patch(
+            "api.routes.graphs.refresh_database_schema", new=AsyncMock(side_effect=error)
+        ):
+            response = client.post("/graphs/testdb/refresh", headers=BEARER)
+
+        assert response.status_code == status
+        assert response.json() == {"error": message}
+
+    def test_get_user_rules(self, client):
+        """Rules are returned under a ``user_rules`` key."""
+        with patch(
+            "api.routes.graphs.get_user_rules", new=AsyncMock(return_value="be brief")
+        ):
+            response = client.get("/graphs/testdb/user-rules", headers=BEARER)
+
+        assert response.status_code == 200
+        assert response.json() == {"user_rules": "be brief"}
+
+    def test_get_user_rules_missing_graph(self, client):
+        """An unknown graph is a 404."""
+        with patch(
+            "api.routes.graphs.get_user_rules",
+            new=AsyncMock(side_effect=GraphNotFoundError("missing")),
+        ):
+            response = client.get("/graphs/testdb/user-rules", headers=BEARER)
+
+        assert response.status_code == 404
+        assert response.json() == {"error": "Database not found"}
+
+    def test_update_user_rules(self, client):
+        """Updating rules echoes the stored value."""
+        setter = AsyncMock()
+        with patch("api.routes.graphs.set_user_rules", new=setter):
+            response = client.put(
+                "/graphs/testdb/user-rules",
+                headers=BEARER,
+                json={"user_rules": "be brief"},
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {"success": True, "user_rules": "be brief"}
+        setter.assert_awaited_once()
+
+    def test_update_user_rules_rejected_for_demo_graph(self, client):
+        """Demo databases are read-only."""
+        with patch("api.routes.graphs.GENERAL_PREFIX", "demo_"):
+            response = client.put(
+                "/graphs/demo_sales/user-rules",
+                headers=BEARER,
+                json={"user_rules": "be brief"},
+            )
+
+        assert response.status_code == 403
+        assert response.json() == {
+            "error": "Rules cannot be modified for demo databases"
+        }
+
+
+@pytest.mark.usefixtures("authed")
+class TestDatabaseRoute:
+    """``api/routes/database.py``."""
+
+    def test_connect_streams_loader_progress(self, client):
+        """The connect endpoint streams whatever the loader yields."""
+        with patch(
+            "api.routes.database.load_database",
+            new=AsyncMock(return_value=_agen("step-1", "step-2")),
+        ) as loader:
+            response = client.post(
+                "/database",
+                headers=BEARER,
+                json={"url": "postgresql://u:p@localhost:5432/testdb"},
+            )
+
+        assert response.status_code == 200
+        assert response.text == "step-1step-2"
+        assert loader.await_args.args[0] == "postgresql://u:p@localhost:5432/testdb"
+
+    def test_connect_requires_url(self, client):
+        """A body without ``url`` fails request validation."""
+        response = client.post("/database", headers=BEARER, json={})
+
+        assert response.status_code == 422
+
+
+@pytest.mark.usefixtures("authed")
+class TestSettingsRoute:
+    """``api/routes/settings.py``."""
+
+    @pytest.mark.parametrize(
+        "body,status,error",
+        [
+            ({"api_key": "  "}, 400, "API key is required"),
+            (
+                {"api_key": "sk-test", "vendor": "bedrock"},
+                400,
+                "Unsupported vendor for key validation",
+            ),
+            ({"api_key": "sk-test", "model": " "}, 400, "Model name is required"),
+            ({"api_key": "nope"}, 400, "Invalid OpenAI API key format"),
+            (
+                {"api_key": "sk-test", "vendor": "anthropic"},
+                400,
+                "Invalid Anthropic API key format",
+            ),
+        ],
+    )
+    def test_rejects_bad_input_before_calling_provider(
+        self, client, body, status, error
+    ):
+        """Malformed requests are rejected without an outbound LLM call."""
+        with patch("api.routes.settings.completion") as completion:
+            response = client.post(
+                "/settings/validate-api-key", headers=BEARER, json=body
+            )
+
+        assert response.status_code == status
+        assert error in response.json()["error"]
+        completion.assert_not_called()
+
+    def test_accepts_valid_key(self, client):
+        """A provider response with choices means the key is valid."""
+        with patch(
+            "api.routes.settings.completion",
+            return_value=MagicMock(choices=[MagicMock()]),
+        ):
+            response = client.post(
+                "/settings/validate-api-key",
+                headers=BEARER,
+                json={"api_key": "sk-test"},
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {"valid": True}
+
+    @pytest.mark.parametrize(
+        "detail,status,error",
+        [
+            ("Invalid authentication", 401, "Invalid API key"),
+            ("quota exceeded", 429, "API quota exceeded or rate limited"),
+            ("connection reset", 500, "Failed to validate API key"),
+        ],
+    )
+    def test_maps_provider_errors(self, client, detail, status, error):
+        """Provider failures map to status codes without echoing the exception."""
+        # The provider error carries the submitted key; it must never come back out.
+        provider_error = RuntimeError(f"{detail} for key sk-test")
+        with patch("api.routes.settings.completion", side_effect=provider_error):
+            response = client.post(
+                "/settings/validate-api-key",
+                headers=BEARER,
+                json={"api_key": "sk-test"},
+            )
+
+        assert response.status_code == status
+        assert response.json() == {"valid": False, "error": error}
+        assert "sk-test" not in response.text
+
+
+@pytest.mark.usefixtures("authed")
+class TestTokensRoutes:
+    """``api/routes/tokens.py``."""
+
+    def test_generate_token(self, client):
+        """A generated token is returned once, in full."""
+        handler = AsyncMock()
+        app.state.callback_handler = handler
+        try:
+            response = client.post("/tokens/generate", headers=BEARER)
+        finally:
+            del app.state.callback_handler
+
+        assert response.status_code == 200
+        assert len(response.json()["token_id"]) > 20
+        assert handler.await_args.args[0] == "api"
+
+    def test_generate_token_without_handler(self, client):
+        """Without a registered callback handler generation fails cleanly."""
+        response = client.post("/tokens/generate", headers=BEARER)
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Failed to generate token"
+
+    def test_list_tokens_returns_last_four_chars(self, client):
+        """Listing never exposes a full token."""
+        graph = MagicMock()
+        graph.query = AsyncMock(
+            return_value=SimpleNamespace(result_set=[["secret-token-wxyz", 1700000000]])
+        )
+        with patch("api.routes.tokens.db") as db:
+            db.select_graph.return_value = graph
+            response = client.get("/tokens/list", headers=BEARER)
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "tokens": [{"token_id": "wxyz", "created_at": 1700000000}]
+        }
+
+    def test_list_tokens_when_none_exist(self, client):
+        """An empty result set is an empty list, not an error."""
+        graph = MagicMock()
+        graph.query = AsyncMock(return_value=SimpleNamespace(result_set=[]))
+        with patch("api.routes.tokens.db") as db:
+            db.select_graph.return_value = graph
+            response = client.get("/tokens/list", headers=BEARER)
+
+        assert response.status_code == 200
+        assert response.json() == {"tokens": []}
+
+    def test_list_tokens_database_error(self, client):
+        """A graph failure is a 500 with a generic message."""
+        graph = MagicMock()
+        graph.query = AsyncMock(side_effect=RuntimeError("graph down"))
+        with patch("api.routes.tokens.db") as db:
+            db.select_graph.return_value = graph
+            response = client.get("/tokens/list", headers=BEARER)
+
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Internal server error"
+
+    def test_delete_token(self, client):
+        """Deleting an existing token reports success."""
+        graph = MagicMock()
+        graph.query = AsyncMock(return_value=SimpleNamespace(result_set=[[1]]))
+        with patch("api.routes.tokens.db") as db:
+            db.select_graph.return_value = graph
+            response = client.delete("/tokens/wxyz", headers=BEARER)
+
+        assert response.status_code == 200
+        assert response.json() == {"message": "Token deleted successfully"}
+
+    def test_delete_unknown_token(self, client):
+        """Deleting a token that is not the user's is a 404."""
+        graph = MagicMock()
+        graph.query = AsyncMock(return_value=SimpleNamespace(result_set=[[0]]))
+        with patch("api.routes.tokens.db") as db:
+            db.select_graph.return_value = graph
+            response = client.delete("/tokens/wxyz", headers=BEARER)
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Token not found"


### PR DESCRIPTION
Stacks on the E2E AI/non-AI split PR — **merge that one first**, then this base retargets to `staging`.

Closes #406. Closes #34.

## Why

The suite was untrusted because it flaked, and the local entry points didn't run the same thing CI ran. Three root causes, all fixed here.

### 1. Polling instead of auto-waiting (#406)

`e2e/infra/utils.ts` implemented its wait helpers as sample-and-sleep loops (`isVisible()` every 500-1000ms). Anything shorter-lived than the sampling interval — toasts, inline confirmations — could be missed entirely, which is exactly the confirmation-dialog flake in #406.

Replaced the loops with Playwright's auto-waiting (`locator.waitFor` / `expect(...).toBeEnabled`). Signatures are unchanged, so the ~90 call sites across the page objects are untouched; `time` and `retry` now define the total budget rather than a sampling cadence.

Alongside that, per #406: `waitForConfirmationMessage` default 10000 → 30000ms, plus a new `waitForConfirmationToDisappear` so the post-confirm assertion waits for the dialog to go away instead of sampling once and asserting falsy.

`'destructive operation shows inline confirmation and executes on confirm'` is marked `test.slow()` — a 30s confirmation wait plus a 50s processing wait cannot fit the 60s describe-level budget.

### 2. Token list read race

`create two tokens and verify via UI` flaked on the first full run: `getAllTokenRows()` took a one-shot `waitForSelector` snapshot, so a re-render between the wait resolving and `.all()` returning yielded `[]`. Now polls the row count. Confirmed with `--repeat-each=5`.

### 3. Makefile pointed at nothing

`make test-e2e`, `test-e2e-headed` and `test-e2e-debug` all ran `pytest tests/e2e/` — a directory that does not exist. They now invoke Playwright, and `make test-e2e-no-ai` mirrors the non-AI CI step. `make clean` cleans `e2e/.auth/` rather than a stale screenshots path.

## API route tests (#34)

`tests/test_api_routes.py` — 58 tests, request/response coverage for every route under `api/routes/`:

- 401 for all 14 authenticated routes; `/version` public.
- Graphs: list, schema, delete, upload matrix, and the `GraphNotFoundError` → 404 / `InvalidArgumentError` → 400 / `InternalError` → 500 mappings.
- Streaming contract for `POST /graphs/{id}`, `/confirm`, `/refresh` and `/database`, asserting the `MESSAGE_DELIMITER` framing.
- Settings validation matrix, including asserting the submitted key never appears in an error response.
- Tokens: generate, list (last-4 masking), delete.

Two findings worth a separate look, not fixed here:

- `POST /graphs` declares a JSON `GraphData` body *and* `file: UploadFile = File(None)`. The `File(...)` default forces multipart parsing, so a JSON body never populates `data` and the documented JSON branch is unreachable — the endpoint returns 415. The test asserts the actual behaviour.
- `api/extensions.py` opens a FalkorDB connection at import time, so every unit test needs a live database. CI provides one, but it makes the suite slower and more brittle than it needs to be.

## Verification

- Full suite, twice consecutively against a live stack: **35 passed, 0 failed, 0 flaky** (3.3m, 3.7m).
- Previously flaky test: 5/5 green under `--repeat-each=5`.
- Unit suite: 253 passed, 1 skipped. `tests/test_api_routes.py`: 58 passed, pylint clean.
- `tsc --noEmit` over `e2e/**`: clean.

Part of FalkorDB/research#91.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
