### PR TITLE
fix(api): dispatch POST /graphs on Content-Type

### DIFF
--- a/api/routes/graphs.py
+++ b/api/routes/graphs.py
@@ -3,9 +3,10 @@
 import json
 import logging
 import uuid
-from fastapi import APIRouter, Request, HTTPException, UploadFile, File
+from fastapi import APIRouter, Request, HTTPException
 from fastapi.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
+from starlette.datastructures import UploadFile
 
 from api.core.schema_loader import list_databases
 from api.core.text2sql import (
@@ -129,11 +130,31 @@ async def get_graph_data(
         )
 
 
+_LOADER_BY_EXTENSION = {
+    ".json": "JSONLoader",
+    ".xml": "ODataLoader",
+    ".csv": "CSVLoader",
+}
+
+
+async def _load_graph_from_upload(request: Request):
+    """Dispatch a multipart upload to the loader matching the file extension."""
+    form = await request.form()
+    file = form.get("file")
+    if not isinstance(file, UploadFile) or not file.filename:
+        raise HTTPException(status_code=415, detail="Missing file upload")
+
+    _, _, extension = file.filename.rpartition(".")
+    loader = _LOADER_BY_EXTENSION.get(f".{extension.lower()}")
+    if loader is None:
+        raise HTTPException(status_code=415, detail="Unsupported file type")
+
+    raise HTTPException(status_code=501, detail=f"{loader} is not implemented yet")
+
+
 @graphs_router.post("", responses={401: UNAUTHORIZED_RESPONSE})
 @token_required
-async def load_graph(
-    request: Request, data: GraphData = None, file: UploadFile = File(None)
-):  # pylint: disable=unused-argument
+async def load_graph(request: Request):
     """
     This route is used to load the graph data into the database.
     It expects either:
@@ -141,35 +162,27 @@ async def load_graph(
     - A File upload (multipart/form-data)
     - An XML payload (application/xml or text/xml)
     """
+    # Dispatch on Content-Type by hand: declaring both a JSON body model and an
+    # `UploadFile` parameter makes FastAPI parse every request as multipart, so
+    # the JSON and XML branches would be unreachable.
+    content_type = request.headers.get("content-type", "").split(";")[0].strip().lower()
 
-    # ✅ Handle JSON Payload
-    if data:  # pylint: disable=no-else-raise
+    if content_type == "application/json":
+        try:
+            GraphData(**await request.json())
+        except (ValueError, TypeError, ValidationError) as exc:
+            raise HTTPException(
+                status_code=422, detail="Invalid JSON payload"
+            ) from exc
         raise HTTPException(status_code=501, detail="JSONLoader is not implemented yet")
-    # ✅ Handle File Upload
-    elif file:
-        filename = file.filename
 
-        # ✅ Check if file is JSON
-        if filename.endswith(".json"):  # pylint: disable=no-else-raise
-            raise HTTPException(
-                status_code=501, detail="JSONLoader is not implemented yet"
-            )
+    if content_type in ("application/xml", "text/xml"):
+        raise HTTPException(status_code=501, detail="ODataLoader is not implemented yet")
 
-        # ✅ Check if file is XML
-        elif filename.endswith(".xml"):
-            raise HTTPException(
-                status_code=501, detail="ODataLoader is not implemented yet"
-            )
+    if content_type == "multipart/form-data":
+        return await _load_graph_from_upload(request)
 
-        # ✅ Check if file is csv
-        elif filename.endswith(".csv"):
-            raise HTTPException(
-                status_code=501, detail="CSVLoader is not implemented yet"
-            )
-        else:
-            raise HTTPException(status_code=415, detail="Unsupported file type")
-    else:
-        raise HTTPException(status_code=415, detail="Unsupported Content-Type")
+    raise HTTPException(status_code=415, detail="Unsupported Content-Type")
 
 
 @graphs_router.post(

--- a/api/routes/graphs.py
+++ b/api/routes/graphs.py
@@ -144,8 +144,10 @@ async def _load_graph_from_upload(request: Request):
     if not isinstance(file, UploadFile) or not file.filename:
         raise HTTPException(status_code=415, detail="Missing file upload")
 
-    _, _, extension = file.filename.rpartition(".")
-    loader = _LOADER_BY_EXTENSION.get(f".{extension.lower()}")
+    # `rpartition` yields an empty separator for a dotless name, in which case
+    # the whole filename would otherwise be read as its own extension.
+    _, separator, extension = file.filename.rpartition(".")
+    loader = _LOADER_BY_EXTENSION.get(f".{extension.lower()}") if separator else None
     if loader is None:
         raise HTTPException(status_code=415, detail="Unsupported file type")
 

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -207,6 +207,7 @@ class TestGraphsRoutes:
             ("schema.JSON", 501),
             ("schema.txt", 415),
             ("schema", 415),
+            ("json", 415),
         ],
     )
     def test_load_graph_upload(self, client, filename, status):
@@ -221,7 +222,11 @@ class TestGraphsRoutes:
 
     def test_load_graph_multipart_without_file(self, client):
         """A multipart body with no ``file`` part is rejected."""
-        response = client.post("/graphs", headers=BEARER, data={"database": "testdb"})
+        response = client.post(
+            "/graphs",
+            headers=BEARER,
+            files={"attachment": ("schema.json", b"payload", "application/json")},
+        )
 
         assert response.status_code == 415
 

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -204,7 +204,9 @@ class TestGraphsRoutes:
             ("schema.json", 501),
             ("schema.xml", 501),
             ("schema.csv", 501),
+            ("schema.JSON", 501),
             ("schema.txt", 415),
+            ("schema", 415),
         ],
     )
     def test_load_graph_upload(self, client, filename, status):
@@ -217,11 +219,34 @@ class TestGraphsRoutes:
 
         assert response.status_code == status
 
-    def test_load_graph_json_payload(self, client):
-        """A JSON body never reaches the loader: ``File(None)`` forces multipart parsing."""
-        response = client.post("/graphs", headers=BEARER, json={"database": "testdb"})
+    def test_load_graph_multipart_without_file(self, client):
+        """A multipart body with no ``file`` part is rejected."""
+        response = client.post("/graphs", headers=BEARER, data={"database": "testdb"})
 
         assert response.status_code == 415
+
+    def test_load_graph_json_payload(self, client):
+        """A valid JSON body reaches the (unimplemented) JSON loader."""
+        response = client.post("/graphs", headers=BEARER, json={"database": "testdb"})
+
+        assert response.status_code == 501
+
+    def test_load_graph_rejects_invalid_json_payload(self, client):
+        """A JSON body missing ``database`` fails validation before the loader."""
+        response = client.post("/graphs", headers=BEARER, json={"nope": 1})
+
+        assert response.status_code == 422
+
+    @pytest.mark.parametrize("content_type", ["application/xml", "text/xml"])
+    def test_load_graph_xml_payload(self, client, content_type):
+        """An XML body reaches the (unimplemented) OData loader."""
+        response = client.post(
+            "/graphs",
+            headers={**BEARER, "Content-Type": content_type},
+            content=b"<schema/>",
+        )
+
+        assert response.status_code == 501
 
     def test_load_graph_without_payload(self, client):
         """No body and no file is an unsupported content type."""


### PR DESCRIPTION
Stacks on #721 — merge that first.

## The bug

`POST /graphs` documented three content types but only ever served one:

```python
async def load_graph(
    request: Request, data: GraphData = None, file: UploadFile = File(None)
):
    if data:
        raise HTTPException(501, "JSONLoader is not implemented yet")
    elif file:
        ...
```

Declaring an `UploadFile` parameter makes FastAPI parse **every** request body as `multipart/form-data`. A JSON request therefore left both `data` and `file` unset and fell through to `415 Unsupported Content-Type` — the `if data:` branch was unreachable, and the XML content types named in the docstring were never handled at all.

## The fix

Dispatch on `Content-Type` explicitly instead of relying on FastAPI's body parsing:

- `application/json` → validated against `GraphData`, then `501 JSONLoader is not implemented yet` (invalid bodies now get a `422` instead of a misleading `415`).
- `application/xml` / `text/xml` → `501 ODataLoader is not implemented yet`.
- `multipart/form-data` → the `file` part is resolved via `request.form()` and routed by extension (`.json`/`.xml`/`.csv` → `501`, anything else → `415`). Extension matching is now case-insensitive and a missing `file` part is a clean `415`.
- Anything else → `415 Unsupported Content-Type`.

All loaders remain unimplemented; this only makes the endpoint's actual behaviour match its documented contract.

Note: `request.form()` returns Starlette's `UploadFile`, not the FastAPI subclass, so the type check imports from `starlette.datastructures`.

## Tests

`tests/test_api_routes.py` previously pinned the broken behaviour (`test_load_graph_json_payload` asserted `415` with a docstring explaining why the JSON branch was dead). Updated to assert the fixed contract, plus new cases for XML bodies, invalid JSON payloads, uppercase extensions, extensionless filenames, and multipart without a `file` part.

64 passed in `tests/test_api_routes.py`; 259 passed / 1 skipped across the unit suite; pylint 10.00/10.

Found while writing the route tests in #721.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
