### PR TITLE
chore(deps): hold typescript 7 and openai 3 back with a guarded ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,11 +15,38 @@ updates:
     target-branch: "staging"
     schedule:
       interval: "weekly"
+    ignore:
+      # openai 3 cannot be adopted while litellm caps it: every litellm from
+      # 1.96.2 onward requires "openai>=2.20.0,<3.0.0". The only release whose
+      # constraint admits openai 3 is litellm 1.83.0, which is also the floor in
+      # pyproject.toml, so resolving openai 3 silently drags litellm down to
+      # 1.83.0 - a version carrying 11 advisories, 2 of them critical (SQL
+      # injection in proxy API key verification, authentication bypass via host
+      # header injection). That downgrade, not openai itself, is what fails
+      # dependency-review. 2.x updates still come through.
+      # Remove this block when litellm allows openai 3 -
+      # tests/test_dependency_holds.py fails for as long as the hold and
+      # litellm's own metadata disagree.
+      - dependency-name: "openai"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "npm"
     directory: "/app"
     target-branch: "staging"
     schedule:
       interval: "weekly"
+    ignore:
+      # TypeScript 7 (the native Go port) ships no programmatic compiler API, so
+      # typescript-eslint cannot support it: the latest release (8.70.0) still
+      # declares "typescript: >=4.8.4 <6.1.0" and there is no 9.x line, which
+      # makes `npm install` fail with ERESOLVE. tsconfig.app.json also uses
+      # baseUrl, which TS 7 removed (TS5101). Nothing here runs tsc - the build
+      # is `vite build` - so TypeScript exists only for typescript-eslint and
+      # editors, and the major buys nothing until typescript-eslint catches up.
+      # Remove this block when typescript-eslint's peer range admits TS 7 -
+      # tests/test_dependency_holds.py fails for as long as the hold and that
+      # peer range disagree.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       npm-minor-patch:
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,9 +42,9 @@ updates:
       # baseUrl, which TS 7 removed (TS5101). Nothing here runs tsc - the build
       # is `vite build` - so TypeScript exists only for typescript-eslint and
       # editors, and the major buys nothing until typescript-eslint catches up.
-      # Remove this block when typescript-eslint's peer range admits TS 7 -
-      # tests/test_dependency_holds.py fails for as long as the hold and that
-      # peer range disagree.
+      # Remove this block once typescript-eslint's peer range admits TS 7 *and*
+      # the tsconfigs drop baseUrl - tests/test_dependency_holds.py fails for as
+      # long as this hold and those two blockers disagree.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
     groups:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ dev = [
     "pylint~=4.0.3",
     "playwright>=1.60,<1.63",
     "pytest-playwright>=0.8,<0.10",
+    # tests/test_dependency_holds.py parses .github/dependabot.yml. It resolved
+    # transitively before, so a lock refresh could have taken it away.
+    "pyyaml>=6.0",
 ]
 
 # All dependencies (server + dev)
@@ -87,6 +90,7 @@ dev = [
     "playwright>=1.60,<1.63",
     "pytest-playwright>=0.8,<0.10",
     "pytest-asyncio~=1.4.0",
+    "pyyaml>=6.0",
 ]
 
 [build-system]

--- a/tests/test_dependency_holds.py
+++ b/tests/test_dependency_holds.py
@@ -76,8 +76,7 @@ def _litellm_openai_specifier() -> SpecifierSet:
 @pytest.mark.unit
 def test_openai_major_is_held_exactly_while_litellm_forbids_it():
     specifier = _litellm_openai_specifier()
-    # prereleases=True so a 3.0.0rc release does not read as "still forbidden".
-    litellm_allows_openai_3 = specifier.contains(Version("3.0.0"), prereleases=True)
+    litellm_allows_openai_3 = specifier.contains(Version("3.0.0"))
     held = "openai" in _major_holds("uv", "/")
 
     if litellm_allows_openai_3:
@@ -114,9 +113,47 @@ def _typescript_eslint_peer_range() -> str:
 
 
 def _lowest_excluded_major(peer_range: str) -> int | None:
-    """Smallest major the range rules out via a ``<`` bound, or None when unbounded above."""
-    bounds = re.findall(r"<\s*=?\s*(\d+)\.", peer_range)
-    return min(int(bound) for bound in bounds) if bounds else None
+    """Smallest major the range rules out entirely, or None when unbounded above.
+
+    Upper bounds get written several ways and the difference matters: ``<7``,
+    ``<7.0`` and ``<7.0.0`` all rule out every 7.x, while ``<7.1`` and ``<=7.1``
+    still admit 7.0, so the first major they exclude outright is 8.
+    """
+    for unsupported, description in (("||", "an alternation"), (" - ", "a hyphen range")):
+        assert unsupported not in peer_range, (
+            f"Peer range {peer_range!r} contains {description}, which this check cannot read - "
+            "a branch admitting the next major would be invisible to it. Read the range and "
+            "update the hold in .github/dependabot.yml by hand."
+        )
+
+    excluded = []
+    for operator, major, tail in re.findall(r"(<=?)\s*v?(\d+)((?:\.\d+)*)", peer_range):
+        # `<=` always leaves its own major partly allowed, and so does a `<`
+        # bound with a non-zero minor or patch.
+        admits_part_of_major = operator == "<=" or any(
+            part != "0" for part in tail.split(".")[1:]
+        )
+        excluded.append(int(major) + 1 if admits_part_of_major else int(major))
+    return min(excluded) if excluded else None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("peer_range", "expected"),
+    [
+        (">=4.8.4 <6.1.0", 7),  # the range in the lockfile today
+        (">=4.8.4 <7.0.0", 7),
+        (">=4.8.4 <7.0", 7),
+        (">=4.8.4 <7", 7),  # no dot: still excludes all of 7.x
+        (">=4.8.4 <=6.9.0", 7),  # <= leaves part of 6 allowed
+        (">=4.8.4 <=7", 8),
+        (">=4.8.4", None),  # genuinely unbounded above
+        ("*", None),
+    ],
+)
+def test_lowest_excluded_major_reads_every_upper_bound_spelling(peer_range, expected):
+    """The hold hangs off this parse, so a range it misreads silently stops enforcing."""
+    assert _lowest_excluded_major(peer_range) == expected
 
 
 def _declared_major(version_range: str) -> int:

--- a/tests/test_dependency_holds.py
+++ b/tests/test_dependency_holds.py
@@ -1,0 +1,149 @@
+"""Dependabot majors held back for a reason must be released once the reason goes.
+
+Two majors are pinned down in ``.github/dependabot.yml``:
+
+* ``openai`` 3, because litellm requires ``openai<3.0.0`` and the only litellm
+  that permits openai 3 is 1.83.0, which carries two critical advisories.
+* ``typescript`` 7, because typescript-eslint's peer range stops below 6.1.
+
+An ``ignore`` entry is invisible: nothing fails when the upstream constraint is
+finally relaxed, so the hold quietly turns into an unexplained pin and the
+dependency rots. These tests read the reason from the same place the resolver
+does - litellm's installed metadata and typescript-eslint's recorded peer
+range - and fail in *both* directions: if the hold is dropped while the
+constraint still stands, and if the constraint lifts while the hold remains.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+try:  # Python 3.12 always has this; guard keeps the import obvious.
+    from importlib.metadata import requires as distribution_requires
+except ImportError:  # pragma: no cover - unreachable on requires-python >=3.12
+    distribution_requires = None
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEPENDABOT_CONFIG = REPO_ROOT / ".github" / "dependabot.yml"
+APP_PACKAGE_JSON = REPO_ROOT / "app" / "package.json"
+APP_PACKAGE_LOCK = REPO_ROOT / "app" / "package-lock.json"
+
+MAJOR_UPDATE = "version-update:semver-major"
+
+
+def _major_holds(ecosystem: str, directory: str) -> set[str]:
+    """Names whose *major* updates ``.github/dependabot.yml`` ignores for one ecosystem."""
+    config = yaml.safe_load(DEPENDABOT_CONFIG.read_text(encoding="utf-8"))
+    entries = [
+        update
+        for update in config["updates"]
+        if update["package-ecosystem"] == ecosystem and update["directory"] == directory
+    ]
+    assert entries, (
+        f"No {ecosystem!r} update block for {directory!r} in .github/dependabot.yml. "
+        "If the ecosystem was renamed or removed, move or delete the hold this test guards."
+    )
+    return {
+        ignored["dependency-name"]
+        for update in entries
+        for ignored in update.get("ignore", [])
+        if MAJOR_UPDATE in ignored.get("update-types", [])
+    }
+
+
+def _litellm_openai_specifier() -> SpecifierSet:
+    """The openai range litellm itself declares, read from the installed distribution."""
+    declared = distribution_requires("litellm") or []
+    openai_requirements = [
+        requirement
+        for requirement in (Requirement(entry) for entry in declared)
+        if requirement.name == "openai" and requirement.marker is None
+    ]
+    assert len(openai_requirements) == 1, (
+        f"Expected exactly one unconditional openai requirement in litellm's metadata, "
+        f"got {[str(r) for r in openai_requirements]}. The hold in .github/dependabot.yml "
+        "is justified by that requirement, so re-read it before trusting this test."
+    )
+    return openai_requirements[0].specifier
+
+
+@pytest.mark.unit
+def test_openai_major_is_held_exactly_while_litellm_forbids_it():
+    specifier = _litellm_openai_specifier()
+    # prereleases=True so a 3.0.0rc release does not read as "still forbidden".
+    litellm_allows_openai_3 = specifier.contains(Version("3.0.0"), prereleases=True)
+    held = "openai" in _major_holds("uv", "/")
+
+    if litellm_allows_openai_3:
+        assert not held, (
+            f"litellm now permits openai 3 ({specifier}), so the hold in .github/dependabot.yml "
+            "is stale - drop the openai ignore block and let the major through."
+        )
+    else:
+        assert held, (
+            f"litellm still requires {specifier}, so resolving openai 3 falls back to litellm "
+            "1.83.0 (two critical advisories). Restore the openai major hold in "
+            ".github/dependabot.yml instead of removing it."
+        )
+
+
+def _typescript_eslint_peer_range() -> str:
+    """typescript-eslint's declared peer range on typescript, from the committed lockfile."""
+    lockfile = json.loads(APP_PACKAGE_LOCK.read_text(encoding="utf-8"))
+    entries = [
+        package
+        for name, package in lockfile["packages"].items()
+        if name.split("node_modules/")[-1] == "typescript-eslint"
+    ]
+    assert len(entries) == 1, (
+        f"Expected exactly one typescript-eslint entry in app/package-lock.json, found {len(entries)}. "
+        "The typescript hold is justified by its peer range, so re-read it before trusting this test."
+    )
+    peer_range = entries[0].get("peerDependencies", {}).get("typescript")
+    assert peer_range, (
+        "typescript-eslint no longer declares a peer dependency on typescript. That removes the "
+        "reason for the typescript major hold in .github/dependabot.yml - re-check it."
+    )
+    return peer_range
+
+
+def _lowest_excluded_major(peer_range: str) -> int | None:
+    """Smallest major the range rules out via a ``<`` bound, or None when unbounded above."""
+    bounds = re.findall(r"<\s*=?\s*(\d+)\.", peer_range)
+    return min(int(bound) for bound in bounds) if bounds else None
+
+
+def _declared_major(version_range: str) -> int:
+    match = re.search(r"(\d+)\.", version_range)
+    assert match, f"Cannot read a major version out of {version_range!r}."
+    return int(match.group(1))
+
+
+@pytest.mark.unit
+def test_typescript_major_is_held_exactly_while_typescript_eslint_rejects_it():
+    peer_range = _typescript_eslint_peer_range()
+    declared = json.loads(APP_PACKAGE_JSON.read_text(encoding="utf-8"))
+    next_major = _declared_major(declared["devDependencies"]["typescript"]) + 1
+
+    excluded_from = _lowest_excluded_major(peer_range)
+    peer_rejects_next_major = excluded_from is not None and excluded_from <= next_major
+    held = "typescript" in _major_holds("npm", "/app")
+
+    if peer_rejects_next_major:
+        assert held, (
+            f"typescript-eslint still declares peer typescript {peer_range!r}, which excludes "
+            f"{next_major}.x, so the bump breaks `npm install` with ERESOLVE. Restore the typescript "
+            "major hold in .github/dependabot.yml instead of removing it."
+        )
+    else:
+        assert not held, (
+            f"typescript-eslint now declares peer typescript {peer_range!r}, which admits "
+            f"{next_major}.x, so the hold in .github/dependabot.yml is stale. Drop the typescript "
+            "ignore block and migrate (tsconfig.app.json still uses baseUrl, removed in TS 7)."
+        )

--- a/tests/test_dependency_holds.py
+++ b/tests/test_dependency_holds.py
@@ -54,10 +54,51 @@ def _major_holds(ecosystem: str, directory: str) -> set[str]:
     )
     return {
         ignored["dependency-name"]
+        # `or []` rather than a default, because these keys can be present *and*
+        # empty. Deleting the last entry but leaving `ignore:` behind is exactly
+        # how a hold gets dropped, and YAML reads that as None - which must mean
+        # "nothing held", not raise TypeError out of the guard.
         for update in entries
-        for ignored in update.get("ignore", [])
-        if MAJOR_UPDATE in ignored.get("update-types", [])
+        for ignored in (update.get("ignore") or [])
+        if MAJOR_UPDATE in (ignored.get("update-types") or [])
     }
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("ignore_block", "expected"),
+    [
+        (
+            '    ignore:\n'
+            '      - dependency-name: "typescript"\n'
+            '        update-types: ["version-update:semver-major"]\n',
+            {"typescript"},
+        ),
+        ("    ignore:\n", set()),
+        ("", set()),
+        (
+            '    ignore:\n      - dependency-name: "typescript"\n        update-types:\n',
+            set(),
+        ),
+    ],
+    ids=["held", "ignore-key-left-empty", "no-ignore-key", "update-types-left-empty"],
+)
+def test_reading_holds_survives_a_half_deleted_ignore_block(
+    ignore_block, expected, tmp_path, monkeypatch
+):
+    """Emptying a key without removing it is how a hold gets dropped by hand.
+
+    YAML reads a present-but-empty key as None, and iterating that raises
+    TypeError - which would replace this guard's explanatory failure with a
+    stack trace at exactly the moment someone is editing the hold.
+    """
+    config = tmp_path / "dependabot.yml"
+    config.write_text(
+        'version: 2\nupdates:\n  - package-ecosystem: "npm"\n    directory: "/app"\n' + ignore_block,
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("tests.test_dependency_holds.DEPENDABOT_CONFIG", config)
+    assert _major_holds("npm", "/app") == expected
 
 
 def _litellm_openai_specifier() -> SpecifierSet:

--- a/tests/test_dependency_holds.py
+++ b/tests/test_dependency_holds.py
@@ -4,7 +4,9 @@ Two majors are pinned down in ``.github/dependabot.yml``:
 
 * ``openai`` 3, because litellm requires ``openai<3.0.0`` and the only litellm
   that permits openai 3 is 1.83.0, which carries two critical advisories.
-* ``typescript`` 7, because typescript-eslint's peer range stops below 6.1.
+* ``typescript`` 7, because typescript-eslint's peer range stops below 6.1 and
+  the app tsconfigs still set ``baseUrl``, which TS 7 removed. Either one alone
+  keeps the hold alive.
 
 An ``ignore`` entry is invisible: nothing fails when the upstream constraint is
 finally relaxed, so the hold quietly turns into an unexplained pin and the
@@ -31,6 +33,7 @@ except ImportError:  # pragma: no cover - unreachable on requires-python >=3.12
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEPENDABOT_CONFIG = REPO_ROOT / ".github" / "dependabot.yml"
+APP_DIR = REPO_ROOT / "app"
 APP_PACKAGE_JSON = REPO_ROOT / "app" / "package.json"
 APP_PACKAGE_LOCK = REPO_ROOT / "app" / "package-lock.json"
 
@@ -162,25 +165,58 @@ def _declared_major(version_range: str) -> int:
     return int(match.group(1))
 
 
+def _tsconfigs_setting_base_url() -> list[str]:
+    """App tsconfigs that still set ``baseUrl``, which TypeScript 7 removed (TS5101).
+
+    These files are JSONC - they carry ``/* ... */`` comments - so they are
+    scanned as text rather than parsed.
+    """
+    tsconfigs = sorted(APP_DIR.glob("tsconfig*.json"))
+    assert tsconfigs, (
+        f"No tsconfig*.json under {APP_DIR}. A baseUrl in those files is one of the two "
+        "reasons for the typescript major hold in .github/dependabot.yml, so re-read the "
+        "hold before trusting this test."
+    )
+    return [
+        path.name
+        for path in tsconfigs
+        if re.search(r'^\s*"baseUrl"\s*:', path.read_text(encoding="utf-8"), re.MULTILINE)
+    ]
+
+
 @pytest.mark.unit
-def test_typescript_major_is_held_exactly_while_typescript_eslint_rejects_it():
+def test_typescript_major_is_held_exactly_while_anything_blocks_it():
     peer_range = _typescript_eslint_peer_range()
     declared = json.loads(APP_PACKAGE_JSON.read_text(encoding="utf-8"))
     next_major = _declared_major(declared["devDependencies"]["typescript"]) + 1
 
     excluded_from = _lowest_excluded_major(peer_range)
-    peer_rejects_next_major = excluded_from is not None and excluded_from <= next_major
+    base_url_configs = _tsconfigs_setting_base_url()
+
+    blockers = []
+    if excluded_from is not None and excluded_from <= next_major:
+        blockers.append(
+            f"typescript-eslint declares peer typescript {peer_range!r}, which excludes "
+            f"{next_major}.x, so the bump breaks `npm install` with ERESOLVE"
+        )
+    if base_url_configs:
+        blockers.append(
+            f"{', '.join(base_url_configs)} still set baseUrl, which TypeScript 7 "
+            "removed (TS5101)"
+        )
+
     held = "typescript" in _major_holds("npm", "/app")
 
-    if peer_rejects_next_major:
+    if blockers:
         assert held, (
-            f"typescript-eslint still declares peer typescript {peer_range!r}, which excludes "
-            f"{next_major}.x, so the bump breaks `npm install` with ERESOLVE. Restore the typescript "
-            "major hold in .github/dependabot.yml instead of removing it."
+            f"typescript {next_major} is still blocked: "
+            + "; ".join(blockers)
+            + ". Restore the typescript major hold in .github/dependabot.yml instead of "
+            "removing it."
         )
     else:
         assert not held, (
-            f"typescript-eslint now declares peer typescript {peer_range!r}, which admits "
-            f"{next_major}.x, so the hold in .github/dependabot.yml is stale. Drop the typescript "
-            "ignore block and migrate (tsconfig.app.json still uses baseUrl, removed in TS 7)."
+            f"Nothing blocks typescript {next_major} any more - typescript-eslint's peer "
+            f"range {peer_range!r} admits it and no app tsconfig sets baseUrl - so the hold "
+            "in .github/dependabot.yml is stale. Drop the typescript ignore block."
         )

--- a/uv.lock
+++ b/uv.lock
@@ -2237,6 +2237,7 @@ all = [
     { name = "pytest-asyncio" },
     { name = "pytest-playwright" },
     { name = "python-multipart" },
+    { name = "pyyaml" },
     { name = "snowflake-connector-python" },
     { name = "uvicorn" },
 ]
@@ -2246,6 +2247,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-playwright" },
+    { name = "pyyaml" },
 ]
 memory = [
     { name = "graphiti-core" },
@@ -2271,6 +2273,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-playwright" },
+    { name = "pyyaml" },
 ]
 
 [package.metadata]
@@ -2310,6 +2313,8 @@ requires-dist = [
     { name = "python-dotenv", specifier = "~=1.2.2" },
     { name = "python-multipart", marker = "extra == 'all'", specifier = "~=0.0.32" },
     { name = "python-multipart", marker = "extra == 'server'", specifier = "~=0.0.32" },
+    { name = "pyyaml", marker = "extra == 'all'", specifier = ">=6.0" },
+    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "snowflake-connector-python", marker = "extra == 'all'", specifier = ">=4.6,<4.8" },
     { name = "snowflake-connector-python", marker = "extra == 'server'", specifier = ">=4.6,<4.8" },
     { name = "sqlglot", specifier = ">=30.12.0" },
@@ -2326,6 +2331,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3,<9.2.0" },
     { name = "pytest-asyncio", specifier = "~=1.4.0" },
     { name = "pytest-playwright", specifier = ">=0.8,<0.10" },
+    { name = "pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Follow-up to #750, which combined every Dependabot update that could actually be resolved. Two were left out because they cannot be made green, and this makes that decision explicit and self-expiring instead of leaving two red PRs open indefinitely.

## Why each is blocked

**#729 — typescript 6.0.3 → 7.0.2**

TypeScript 7 is the native Go port and ships no programmatic compiler API, so typescript-eslint cannot support it. The latest release still rejects it, and there is no newer line:

```
$ npm view typescript-eslint@latest version peerDependencies
8.70.0   typescript: ">=4.8.4 <6.1.0"      # no 9.x line exists
```

So `npm install` fails with `ERESOLVE`. Separately `tsconfig.app.json` uses `baseUrl`, which TS 7 removed (`TS5101`).

Worth recording: **nothing in this repo runs `tsc`**. `app/package.json` builds with `vite build` and lints with `eslint .`; the only `tsc` string anywhere is the typescript package's own bin entry in the lockfile. TypeScript here serves typescript-eslint and editors only, so the major buys nothing until typescript-eslint catches up.

**#702 — openai 2.48.0 → 3.1.0**

Every litellm from 1.96.2 onward caps openai:

| litellm | declared openai range |
| --- | --- |
| 1.83.0 | `openai>=2.8.0` (unbounded) |
| 1.96.2 | `openai>=2.20.0,<3.0.0` |
| 1.100.0 (current, in `uv.lock`) | `openai>=2.20.0,<3.0.0` |

1.83.0 is the only version that admits openai 3 — and it is also the floor in `pyproject.toml` (`litellm>=1.83.0`), so asking for openai 3 quietly resolves litellm *backwards* to it. That version carries **11 advisories: 2 critical, 7 high**, including SQL injection in proxy API key verification and authentication bypass via host header injection. The downgrade, not openai itself, is what `dependency-review` rejects.

## Why a test and not just an `ignore`

A Dependabot `ignore` entry is invisible. Nothing fails when upstream finally relaxes the constraint, so the hold stops being a considered decision and becomes an unexplained pin that quietly rots.

`tests/test_dependency_holds.py` reads each reason from the same source the resolver uses — litellm's own installed metadata via `importlib.metadata`, and typescript-eslint's recorded `peerDependencies` in `app/package-lock.json` — and asserts in **both** directions:

- hold removed while the constraint still stands → fail
- constraint lifted while the hold remains → fail, with the migration note attached (TS 7 still needs the `baseUrl` fix)

It also fails loudly rather than silently passing if the metadata stops looking the way it is read (missing ecosystem block, absent peer range, more than one openai requirement).

Both directions were mutation-tested: dropping either ignore entry, weakening its `update-types` from major to patch, deleting the `uv` block, and simulating litellm `openai>=2.20.0` / `openai<4.0.0` and peer ranges `>=4.8.4`, `<7.0.0`, `<8.0.0` each produce the expected pass/fail.

## Verification

- `uv run python -m pytest tests/ -k "not e2e and not test_sdk"` — **677 passed**, 1 skipped (675 before, +2 new)
- `make lint` — pylint **10.00/10**, eslint clean
- Spellcheck runs the Markdown task only; this change is YAML and Python

Minor/patch updates for both packages still come through untouched.

Closes #729
Closes #702


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Major OpenAI and TypeScript updates remain on hold until compatibility requirements are met.
  - Minor and patch updates continue as usual.
  - PyYAML is now explicitly included in development dependencies for a more reliable development setup.
  - TypeScript updates can resume once tooling supports the next major version and the remaining configuration requirements are addressed.
  - Documentation now clearly outlines the conditions for removing the TypeScript hold.

- **Tests**
  - Added automated checks to ensure dependency holds remain accurate and are removed when blocking conditions no longer apply.
  - Expanded coverage for malformed configuration, version boundaries, and TypeScript compatibility requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->